### PR TITLE
Red and green flags don't have to be selected , closes #142

### DIFF
--- a/lib/animina_web/components/select_flags_component.ex
+++ b/lib/animina_web/components/select_flags_component.ex
@@ -66,7 +66,7 @@ defmodule AniminaWeb.SelectFlagsComponent do
   def render(assigns) do
     ~H"""
     <div class="py-4 space-y-2">
-      <h3 class="font-semibold text-gray-800 truncate">
+      <h3 class="font-semibold text-gray-800 dark:text-white truncate">
         <%= get_translation(@category.category_translations, @language) %>
       </h3>
 


### PR DESCRIPTION
-In the PR below , I have ensured the user can proceed without selecting  flags , I have also provided different messages on the buttons and flash messages for both scenarios.
- If the user has flags selected , they see "Save Flags" and a flash message of "Your flags have been added successfully".
- If the  user has not selected a flag , they see "Proceed without selecting a flag" and a flash message of "You have proceeded without selecting any flags".
This is the flow now for dark and light themes 

https://github.com/animina-dating/animina/assets/86654131/ea997b23-3dce-4fa1-9302-56a33052748b


https://github.com/animina-dating/animina/assets/86654131/de1a6f00-d302-4614-bc0d-7d571cefe35a



