### PR TITLE
Fix height visualisation to be blocks with the username , closes #207

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -22,6 +22,13 @@ body {
   }
 }
 
+.z0 {
+  z-index: 0 !important;
+}
+.z50 {
+  z-index: 50 !important;
+}
+
 input:invalid:not(:placeholder-shown) {
   background-color: hsl(12, 100%, 95%);
 }

--- a/lib/animina_web/components/animina_components.ex
+++ b/lib/animina_web/components/animina_components.ex
@@ -216,10 +216,10 @@ defmodule AniminaWeb.AniminaComponents do
       <div class="md:w-[40px] dark:bg-white h-[100%] bg-black w-[35px] flex flex-col justify-between  items-center ">
       </div>
       <div class="h-[100%] flex justify-end items-end ">
-        <div class="bg-white flex  justify-end flex-col gap-0 px-1 text-xs">
-          <%= for i<- get_shortened_username(@username) do %>
+        <div class="dark:bg-white bg-black flex text-white dark:text-black  justify-end flex-col gap-0 px-1 text-xs">
+          <%= for letter <- get_shortened_username(@username) do %>
             <p class="rotate-90">
-              <%= i %>
+              <%= letter %>
             </p>
           <% end %>
         </div>

--- a/lib/animina_web/components/animina_components.ex
+++ b/lib/animina_web/components/animina_components.ex
@@ -183,12 +183,12 @@ defmodule AniminaWeb.AniminaComponents do
     ~H"""
     <%= if @current_user.gender != "diverse"  &&  @profile_user != "diverse" do %>
       <div class="flex gap-16 bg-[#B2CCEF] dark:bg-gray-800 rounded-md p-4 py-8 justify-start items-end">
-        <div class="flex gap-0">
+        <div class="flex z0 gap-0">
           <p class="h-[100px] dark:bg-white bg-black w-[2px] " />
           <div class="h-[100%] flex  relative">
-            <p class="absolute dark:text-white -top-[12px] text-xs  pb-2">200cm</p>
+            <p class="absolute  dark:text-white -top-[12px] text-xs  pb-2">200cm</p>
 
-            <p class="w-[200px]  absolute top-[2px] mb-[180px] h-[1px] dark:bg-white bg-black" />
+            <p class="w-[200px]   absolute top-[2px] mb-[180px] h-[1px] dark:bg-white bg-black" />
             <p class="absolute top-[16px] dark:text-white text-xs  pb-3">150cm</p>
             <p class="w-[200px]   absolute top-[30px]  h-[1px] dark:bg-white bg-black" />
 
@@ -201,19 +201,30 @@ defmodule AniminaWeb.AniminaComponents do
         </div>
 
         <div class="flex items-end gap-8">
-          <.current_user_figure
-            gender={@current_user.gender}
-            height={@current_user_height_for_figure}
-          />
+          <.figure height={@current_user_height_for_figure} username={@current_user.username} />
 
-          <.potential_partner_figure
-            partner_gender={@profile_user.gender}
-            gender={@profile_user.gender}
-            height={@profile_user_height_for_figure}
-          />
+          <.figure height={@profile_user_height_for_figure} username={@profile_user.username} />
         </div>
       </div>
     <% end %>
+    """
+  end
+
+  def figure(assigns) do
+    ~H"""
+    <div class="flex gap-2 items-end justify-end" style={"height:#{@height}px"}>
+      <div class="md:w-[40px] dark:bg-white h-[100%] bg-black w-[35px] flex flex-col justify-between  items-center ">
+      </div>
+      <div class="h-[100%] flex justify-end items-end ">
+        <div class="bg-white flex  justify-end flex-col gap-0 px-1 text-xs">
+          <%= for i<- String.graphemes("#{@username}") do %>
+            <p class="rotate-90">
+              <%= i %>
+            </p>
+          <% end %>
+        </div>
+      </div>
+    </div>
     """
   end
 

--- a/lib/animina_web/components/animina_components.ex
+++ b/lib/animina_web/components/animina_components.ex
@@ -182,21 +182,21 @@ defmodule AniminaWeb.AniminaComponents do
   def height_visualization(assigns) do
     ~H"""
     <%= if @current_user.gender != "diverse"  &&  @profile_user != "diverse" do %>
-      <div class="flex gap-16 bg-[#B2CCEF] dark:bg-gray-800 rounded-md p-4 py-8 justify-start items-end">
+      <div class="flex gap-12 bg-[#B2CCEF] dark:bg-gray-800 rounded-md p-4 py-8 justify-start items-end">
         <div class="flex z0 gap-0">
           <p class="h-[100px] dark:bg-white bg-black w-[2px] " />
           <div class="h-[100%] flex  relative">
             <p class="absolute  dark:text-white -top-[12px] text-xs  pb-2">200cm</p>
 
-            <p class="w-[200px]   absolute top-[2px] mb-[180px] h-[1px] dark:bg-white bg-black" />
+            <p class="w-[230px]   absolute top-[2px] mb-[180px] h-[1px] dark:bg-white bg-black" />
             <p class="absolute top-[16px] dark:text-white text-xs  pb-3">150cm</p>
-            <p class="w-[200px]   absolute top-[30px]  h-[1px] dark:bg-white bg-black" />
+            <p class="w-[230px]   absolute top-[30px]  h-[1px] dark:bg-white bg-black" />
 
             <p class="absolute top-[40px] dark:text-white  text-xs pb-3">100cm</p>
-            <p class="w-[200px]   absolute top-[54px] h-[1px] dark:bg-white bg-black" />
+            <p class="w-[230px]   absolute top-[54px] h-[1px] dark:bg-white bg-black" />
 
             <p class="absolute top-[64px] dark:text-white text-xs  pb-3">50cm</p>
-            <p class="w-[200px]   absolute top-[80px] h-[1px] dark:bg-white bg-black" />
+            <p class="w-[230px]   absolute top-[80px] h-[1px] dark:bg-white bg-black" />
           </div>
         </div>
 
@@ -217,7 +217,7 @@ defmodule AniminaWeb.AniminaComponents do
       </div>
       <div class="h-[100%] flex justify-end items-end ">
         <div class="bg-white flex  justify-end flex-col gap-0 px-1 text-xs">
-          <%= for i<- String.graphemes("#{@username}") do %>
+          <%= for i<- get_shortened_username(@username) do %>
             <p class="rotate-90">
               <%= i %>
             </p>
@@ -295,5 +295,11 @@ defmodule AniminaWeb.AniminaComponents do
       </div>
     </div>
     """
+  end
+
+  defp get_shortened_username(username) do
+    "#{username}"
+    |> String.slice(0, 4)
+    |> String.graphemes()
   end
 end


### PR DESCRIPTION
- In this PR , I made the height visualisation a block with the username for that block to its side 
![Screenshot 2024-04-06 at 09 02 16](https://github.com/animina-dating/animina/assets/86654131/778266c0-bf21-4284-bde4-f4d0254ddc18)
![Screenshot 2024-04-06 at 09 03 37](https://github.com/animina-dating/animina/assets/86654131/3554b93f-7b79-4a10-a51a-b7a7ebda875e)
![Screenshot 2024-04-06 at 09 09 11](https://github.com/animina-dating/animina/assets/86654131/97099eca-c095-4f85-b4c8-d846fc88462a)
