### PR TITLE
Use id of a flag and not flag.name to set green and red dots , closes #213

### DIFF
--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -128,11 +128,11 @@ defmodule AniminaWeb.StoriesComponents do
   def get_styling_for_matching_flags(assigns) do
     ~H"""
     <div class="pl-2">
-      <div :if={@flag.flag.name in @current_user_green_flags}>
+      <div :if={@flag.flag.id in @current_user_green_flags}>
         <p class="h-3 w-3 rounded-full bg-green-500" />
       </div>
 
-      <div :if={@flag.flag.name in @current_user_red_flags}>
+      <div :if={@flag.flag.id in @current_user_red_flags}>
         <p class="h-3 w-3 rounded-full bg-red-500" />
       </div>
     </div>

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -29,11 +29,11 @@ defmodule AniminaWeb.ProfileLive do
 
           current_user_green_flags =
             fetch_flags(socket.assigns.current_user.id, :green, language)
-            |> Enum.map(& &1.flag.name)
+            |> Enum.map(& &1.flag.id)
 
           current_user_red_flags =
             fetch_flags(socket.assigns.current_user.id, :red, language)
-            |> Enum.map(& &1.flag.name)
+            |> Enum.map(& &1.flag.id)
 
           socket
           |> assign(user: user)


### PR DESCRIPTION
- In this PR I changed and used the id flag which is unique as opposed to name to set green and red flags.
