### PR TITLE
Remove the username from the profile

### DIFF
--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -156,8 +156,7 @@ defmodule AniminaWeb.ProfileLive do
 
       <div :if={@user} class="pb-4">
         <h1 class="text-2xl font-semibold dark:text-white">
-          <%= @user.name %> <span class="text-base">@<%= @user.username %></span>
-          <span class="w-3 h-3 bg-green-500 rounded-full" />
+          <%= @user.name %>
         </h1>
 
         <div class="pt-2">


### PR DESCRIPTION
At least for now. We don't need that anywhere but the URL.