### PR TITLE
Allow markdown to be used in the messages , closes #312

### DIFF
--- a/lib/animina/markdown.ex
+++ b/lib/animina/markdown.ex
@@ -1,4 +1,7 @@
 defmodule Animina.Markdown do
+   @moduledoc """
+  This is the markdown module that converts markdown to html
+  """
   def format(text) do
     MDEx.to_html(text,
       extension: [strikethrough: true, autolink: true],

--- a/lib/animina/markdown.ex
+++ b/lib/animina/markdown.ex
@@ -1,0 +1,23 @@
+defmodule Animina.Markdown do
+  def format(text) do
+    MDEx.to_html(text,
+      extension: [strikethrough: true, autolink: true],
+      render: [unsafe_: true],
+      features: [sanitize: true, syntax_highlight_theme: "github_light"]
+    )
+    |> HtmlSanitizeEx.basic_html()
+    |> String.replace(~r/\<img.*>/, "")
+    |> String.replace(~r/\<p/, "<p class='pt-2'")
+    |> String.replace(~r/\<a/, "<a class='text-blue-800 underline decoration-blue-800'")
+    |> String.replace(~r/\<ul/, "<ul class='p-2 pl-8 list-disc'")
+    |> String.replace(~r/\<ol/, "<ol class='p-2 pl-8 list-decimal'")
+    |> String.replace(~r/\<h1/, "<h2 class='pt-4 text-xl font-bold'")
+    |> String.replace(~r/\<h2/, "<h3 class='pt-4 text-base font-bold'")
+    |> String.replace(~r/\<h3/, "<h4 class='pt-4 text-base font-bold'")
+    |> String.replace(
+      ~r/\<blockquote/,
+      "<blockquote class='p-2 my-2 border-gray-300 border-s-4 bg-gray-50 dark:border-gray-500 dark:bg-gray-800'"
+    )
+    |> Phoenix.HTML.raw()
+  end
+end

--- a/lib/animina_web/components/chat/chat_components.ex
+++ b/lib/animina_web/components/chat/chat_components.ex
@@ -3,6 +3,7 @@ defmodule AniminaWeb.ChatComponents do
   Provides Chat UI components.
   """
   use Phoenix.Component
+  alias Animina.Markdown
 
   def send_message_button(assigns) do
     ~H"""
@@ -49,8 +50,18 @@ defmodule AniminaWeb.ChatComponents do
       <div class="flex flex-col w-[100%] md:p-4 p-2    overflow-y-scroll  gap-2">
         <%= for message <-@messages do %>
           <div class="w-[100%]">
-            <.sent_message message={message} sender={@sender} receiver={@receiver} />
-            <.received_message message={message} sender={@sender} receiver={@receiver} />
+            <.sent_message
+              message={message}
+              content={message.content}
+              sender={@sender}
+              receiver={@receiver}
+            />
+            <.received_message
+              message={message}
+              content={message.content}
+              sender={@sender}
+              receiver={@receiver}
+            />
           </div>
         <% end %>
       </div>
@@ -68,7 +79,7 @@ defmodule AniminaWeb.ChatComponents do
           </p>
           <div class="md:w-[300px] w-[250px] bg-blue-500 flex text-white p-2 items-end  rounded-md">
             <p>
-              <%= @message.content %>
+              <%= Markdown.format(@content) %>
             </p>
           </div>
         </div>
@@ -89,7 +100,7 @@ defmodule AniminaWeb.ChatComponents do
           </p>
           <div class="md:w-[300px w-[250px]   dark:bg-white bg-gray-300 text-black  flex p-2 items-end rounded-md">
             <p>
-              <%= @message.content %>
+              <%= Markdown.format(@content) %>
             </p>
           </div>
         </div>

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -3,6 +3,7 @@ defmodule AniminaWeb.StoriesComponents do
   Provides Story UI components.
   """
   use Phoenix.Component
+  alias Animina.Markdown
 
   attr :stories_and_flags, :list, required: true
   attr :current_user, :any, required: true
@@ -151,25 +152,7 @@ defmodule AniminaWeb.StoriesComponents do
   def story_content(assigns) do
     ~H"""
     <div :if={@story.content} class="pb-2 text-justify text-gray-600 text-ellipsis dark:text-gray-100">
-      <%= MDEx.to_html(@story.content,
-        extension: [strikethrough: true, autolink: true],
-        render: [unsafe_: true],
-        features: [sanitize: true, syntax_highlight_theme: "github_light"]
-      )
-      |> HtmlSanitizeEx.basic_html()
-      |> String.replace(~r/\<img.*>/, "")
-      |> String.replace(~r/\<p/, "<p class='pt-2'")
-      |> String.replace(~r/\<a/, "<a class='text-blue-800 underline decoration-blue-800'")
-      |> String.replace(~r/\<ul/, "<ul class='p-2 pl-8 list-disc'")
-      |> String.replace(~r/\<ol/, "<ol class='p-2 pl-8 list-decimal'")
-      |> String.replace(~r/\<h1/, "<h2 class='pt-4 text-xl font-bold'")
-      |> String.replace(~r/\<h2/, "<h3 class='pt-4 text-base font-bold'")
-      |> String.replace(~r/\<h3/, "<h4 class='pt-4 text-base font-bold'")
-      |> String.replace(
-        ~r/\<blockquote/,
-        "<blockquote class='p-2 my-2 border-gray-300 border-s-4 bg-gray-50 dark:border-gray-500 dark:bg-gray-800'"
-      )
-      |> Phoenix.HTML.raw() %>
+      <%= Markdown.format(@story.content) %>
     </div>
     """
   end

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -40,6 +40,7 @@ defmodule AniminaWeb.ChatLive do
     |> to_form()
   end
 
+  @impl true
   def handle_event("validate", %{"message" => params}, socket) do
     form = AshPhoenix.Form.validate(socket.assigns.form, params)
 


### PR DESCRIPTION
- I moved the markdown code to `lib/animina/markdown.ex` for reusability so now when we call `Mardown.format/1` we see the magic.

https://github.com/animina-dating/animina/assets/86654131/55b1d854-a8dc-4794-8d88-2c277a7501cd

