### PR TITLE
Feature/add custom actions for reactions , closes #310

### DIFF
--- a/lib/animina/accounts/resources/reaction.ex
+++ b/lib/animina/accounts/resources/reaction.ex
@@ -35,14 +35,21 @@ defmodule Animina.Accounts.Reaction do
   end
 
   actions do
-    defaults [:read]
+    defaults [:read, :destroy]
 
     create :like do
       accept [:sender_id, :receiver_id]
       change set_attribute(:name, :like)
     end
 
-    destroy :unlike
+    destroy :unlike do
+    end
+
+    destroy :unblock do
+    end
+
+    destroy :unhide do
+    end
 
     create :block do
       accept [:sender_id, :receiver_id]
@@ -60,8 +67,11 @@ defmodule Animina.Accounts.Reaction do
     define :read
     define :like
     define :unlike
+    define :unblock
+    define :unhide
     define :block
     define :hide
+    define :destroy
     define :by_id, get_by: [:id], action: :read
     define :by_sender_and_receiver_id, get_by: [:sender_id, :receiver_id], action: :read
   end

--- a/lib/animina/accounts/resources/reaction.ex
+++ b/lib/animina/accounts/resources/reaction.ex
@@ -35,14 +35,33 @@ defmodule Animina.Accounts.Reaction do
   end
 
   actions do
-    defaults [:create, :read, :destroy]
+    defaults [:read]
+
+    create :like do
+      accept [:sender_id, :receiver_id]
+      change set_attribute(:name, :like)
+    end
+
+    destroy :unlike
+
+    create :block do
+      accept [:sender_id, :receiver_id]
+      change set_attribute(:name, :block)
+    end
+
+    create :hide do
+      accept [:sender_id, :receiver_id]
+      change set_attribute(:name, :hide)
+    end
   end
 
   code_interface do
     define_for Animina.Accounts
     define :read
-    define :create
-    define :destroy
+    define :like
+    define :unlike
+    define :block
+    define :hide
     define :by_id, get_by: [:id], action: :read
     define :by_sender_and_receiver_id, get_by: [:sender_id, :receiver_id], action: :read
   end
@@ -50,6 +69,10 @@ defmodule Animina.Accounts.Reaction do
   policies do
     policy action_type(:create) do
       authorize_if Animina.Checks.CreateReactionCheck
+    end
+
+    policy action_type(:destroy) do
+      authorize_if Animina.Checks.DestroyReactionCheck
     end
   end
 

--- a/lib/animina/checks/destroy_reaction_check.ex
+++ b/lib/animina/checks/destroy_reaction_check.ex
@@ -1,0 +1,15 @@
+defmodule Animina.Checks.DestroyReactionCheck do
+  @moduledoc """
+  Policy for The Reaction Resource
+  """
+  alias Animina.Accounts.User
+  use Ash.Policy.SimpleCheck
+
+  def describe(_opts) do
+    "Check a user cannot delete a reaction to they did not create"
+  end
+
+  def match?(actor, params, _opts) do
+    true
+  end
+end

--- a/lib/animina/checks/destroy_reaction_check.ex
+++ b/lib/animina/checks/destroy_reaction_check.ex
@@ -2,7 +2,7 @@ defmodule Animina.Checks.DestroyReactionCheck do
   @moduledoc """
   Policy for The Reaction Resource
   """
-  alias Animina.Accounts.User
+
   use Ash.Policy.SimpleCheck
 
   def describe(_opts) do
@@ -10,6 +10,10 @@ defmodule Animina.Checks.DestroyReactionCheck do
   end
 
   def match?(actor, params, _opts) do
-    true
+    if actor.id == params.changeset.data.sender_id do
+      true
+    else
+      false
+    end
   end
 end

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -117,11 +117,10 @@ defmodule AniminaWeb.ProfileLive do
 
   @impl true
   def handle_event("add_like", _params, socket) do
-    Reaction.create(
+    Reaction.like(
       %{
         sender_id: socket.assigns.current_user.id,
-        receiver_id: socket.assigns.user.id,
-        name: :like
+        receiver_id: socket.assigns.user.id
       },
       actor: socket.assigns.current_user
     )
@@ -139,7 +138,7 @@ defmodule AniminaWeb.ProfileLive do
     reaction =
       get_reaction_for_sender_and_receiver(socket.assigns.current_user.id, socket.assigns.user.id)
 
-    Reaction.destroy(reaction)
+    Reaction.unlike(reaction, actor: socket.assigns.current_user)
 
     {:noreply,
      socket

--- a/test/animina/accounts/message_test.exs
+++ b/test/animina/accounts/message_test.exs
@@ -223,10 +223,9 @@ defmodule Animina.Accounts.MessageTest do
   end
 
   defp create_like_reaction(sender_id, receiver_id) do
-    Reaction.create(%{
+    Reaction.like(%{
       sender_id: sender_id,
-      receiver_id: receiver_id,
-      name: :like
+      receiver_id: receiver_id
     })
   end
 end

--- a/test/animina/accounts/reaction_test.exs
+++ b/test/animina/accounts/reaction_test.exs
@@ -12,9 +12,67 @@ defmodule Animina.Accounts.ReactionTest do
       ]
     end
 
+    test "The like action creates a reaction with the name :like", %{
+      user_one: user_one,
+      user_two: user_two
+    } do
+      assert {:ok, reaction} =
+               create_like_reaction(
+                 user_one.id,
+                 user_two.id,
+                 user_one
+               )
+
+      assert reaction.name == :like
+    end
+
+    test "The block action creates a reaction with the name :block", %{
+      user_one: user_one,
+      user_two: user_two
+    } do
+      assert {:ok, reaction} =
+               create_block_reaction(
+                 user_one.id,
+                 user_two.id,
+                 user_one
+               )
+
+      assert reaction.name == :block
+    end
+
+    test "The hide action creates a reaction with the name :hide", %{
+      user_one: user_one,
+      user_two: user_two
+    } do
+      assert {:ok, reaction} =
+               create_hide_reaction(
+                 user_one.id,
+                 user_two.id,
+                 user_one
+               )
+
+      assert reaction.name == :hide
+    end
+
+    test "The unlike action deletes a reaction", %{
+      user_one: user_one,
+      user_two: user_two
+    } do
+      assert {:ok, reaction} =
+               create_block_reaction(
+                 user_one.id,
+                 user_two.id,
+                 user_one
+               )
+
+      assert :ok =
+               Reaction.unlike(reaction)
+    end
+
     test "A user cannot create reactions for their own profiles",
          %{
-           user_one: user_one
+           user_one: user_one,
+           user_two: user_two
          } do
       assert {:error, _} =
                create_like_reaction(
@@ -77,11 +135,30 @@ defmodule Animina.Accounts.ReactionTest do
   end
 
   defp create_like_reaction(sender_id, receiver_id, actor) do
-    Reaction.create(
+    Reaction.like(
       %{
         sender_id: sender_id,
-        receiver_id: receiver_id,
-        name: :like
+        receiver_id: receiver_id
+      },
+      actor: actor
+    )
+  end
+
+  defp create_block_reaction(sender_id, receiver_id, actor) do
+    Reaction.block(
+      %{
+        sender_id: sender_id,
+        receiver_id: receiver_id
+      },
+      actor: actor
+    )
+  end
+
+  defp create_hide_reaction(sender_id, receiver_id, actor) do
+    Reaction.hide(
+      %{
+        sender_id: sender_id,
+        receiver_id: receiver_id
       },
       actor: actor
     )

--- a/test/animina/accounts/reaction_test.exs
+++ b/test/animina/accounts/reaction_test.exs
@@ -54,7 +54,25 @@ defmodule Animina.Accounts.ReactionTest do
       assert reaction.name == :hide
     end
 
-    test "The unlike action deletes a reaction", %{
+    test "The unlike action deletes a reaction if the actor created it", %{
+      user_one: user_one,
+      user_two: user_two
+    } do
+      assert {:ok, reaction} =
+               create_like_reaction(
+                 user_one.id,
+                 user_two.id,
+                 user_one
+               )
+
+      assert :ok =
+               Reaction.unlike(reaction, actor: user_one)
+
+      assert {:error, _} =
+               Reaction.unlike(reaction, actor: user_two)
+    end
+
+    test "The unblock action deletes a reaction if the actor created it", %{
       user_one: user_one,
       user_two: user_two
     } do
@@ -66,13 +84,33 @@ defmodule Animina.Accounts.ReactionTest do
                )
 
       assert :ok =
-               Reaction.unlike(reaction)
+               Reaction.unblock(reaction, actor: user_one)
+
+      assert {:error, _} =
+               Reaction.unblock(reaction, actor: user_two)
+    end
+
+    test "The unhide action deletes a reaction if the actor created it", %{
+      user_one: user_one,
+      user_two: user_two
+    } do
+      assert {:ok, reaction} =
+               create_hide_reaction(
+                 user_one.id,
+                 user_two.id,
+                 user_one
+               )
+
+      assert :ok =
+               Reaction.unhide(reaction, actor: user_one)
+
+      assert {:error, _} =
+               Reaction.unhide(reaction, actor: user_two)
     end
 
     test "A user cannot create reactions for their own profiles",
          %{
-           user_one: user_one,
-           user_two: user_two
+           user_one: user_one
          } do
       assert {:error, _} =
                create_like_reaction(


### PR DESCRIPTION
In this PR , I worked on the custom create and destroy actions for the reaction resource , we can now call

`Reaction.like(%{sender_id : sender_id , receiver_id: receiver_id} , actor:user) ` - that creates a reaction with the name :like
`Reaction.hide(%{sender_id : sender_id , receiver_id: receiver_id} , actor:user) ` - that creates a reaction with the name :hide

`Reaction.block(%{sender_id : sender_id , receiver_id: receiver_id} , actor:user) ` - that creates a reaction with the name :block 

To destroy these , we have the following actions

`Reaction.unlike(reaction , actor: user)`


`Reaction.unhide(reaction , actor: user)`


`Reaction.unblock(reaction , actor: user)`


- I also added policies to ensure only the user who sent a reaction can delete it from the database as well as tests