### PR TITLE
Chat shouldn't need a reload , closes #314

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,9 +25,23 @@ import topbar from "../vendor/topbar";
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
   .getAttribute("content");
+
+let Hooks = {};
+
+Hooks.ScrollToBottom = {
+  mounted() {
+    var div = document.getElementById("ChatMessagesBox");
+    div.scrollTop = div.scrollHeight;
+  },
+  updated() {
+    var div = document.getElementById("ChatMessagesBox");
+    div.scrollTop = div.scrollHeight;
+  },
+};
+
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },
-  hooks: {},
+  hooks: Hooks,
 });
 
 // Show progress bar on live navigation and form submits

--- a/lib/animina/accounts/resources/message.ex
+++ b/lib/animina/accounts/resources/message.ex
@@ -39,6 +39,16 @@ defmodule Animina.Accounts.Message do
   actions do
     defaults [:create, :read]
 
+    read :by_id do
+      argument :id, :uuid do
+        allow_nil? false
+      end
+
+      prepare build(load: [:sender, :receiver])
+
+      filter expr(id == ^arg(:id))
+    end
+
     read :messages_for_sender_and_receiver do
       argument :sender_id, :uuid do
         allow_nil? false
@@ -61,6 +71,9 @@ defmodule Animina.Accounts.Message do
     define_for Animina.Accounts
     define :read
     define :create
+
+    define :by_id, args: [:id]
+
     define :messages_for_sender_and_receiver, args: [:sender_id, :receiver_id]
   end
 

--- a/lib/animina_web/components/chat/chat_components.ex
+++ b/lib/animina_web/components/chat/chat_components.ex
@@ -47,7 +47,11 @@ defmodule AniminaWeb.ChatComponents do
   def messages_box(assigns) do
     ~H"""
     <div class="flex h-[100%] flex-col-reverse">
-      <div class="flex flex-col w-[100%] md:p-4 p-2    overflow-y-scroll  gap-2">
+      <div
+        id="ChatMessagesBox"
+        phx-hook="ScrollToBottom"
+        class="flex flex-col w-[100%] md:p-4 p-2  py-8 transition-all duration-500  overflow-y-scroll  gap-2"
+      >
         <%= for message <-@messages do %>
           <div class="w-[100%]">
             <.sent_message

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -75,6 +75,15 @@ defmodule AniminaWeb.ChatLive do
     end
   end
 
+  defp message_belongs_to_current_user_or_profile(message, current_user, profile) do
+    if (message.sender_id == current_user.id and message.receiver_id == profile.id) or
+         (message.sender_id == profile.id and message.receiver_id == current_user.id) do
+      true
+    else
+      false
+    end
+  end
+
   def handle_info({:new_message, message}, socket) do
     {:ok, message} = Message.by_id(message.id)
 
@@ -90,15 +99,6 @@ defmodule AniminaWeb.ChatLive do
       {:noreply, socket |> assign(messages: messages)}
     else
       {:noreply, socket}
-    end
-  end
-
-  defp message_belongs_to_current_user_or_profile(message, current_user, profile) do
-    if (message.sender_id == current_user.id and message.receiver_id == profile.id) or
-         (message.sender_id == profile.id and message.receiver_id == current_user.id) do
-      true
-    else
-      false
     end
   end
 

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -8,12 +8,20 @@ defmodule AniminaWeb.ChatLive do
   alias Phoenix.PubSub
 
   @impl true
-  def mount(%{"current_user" => current_user, "profile" => profile}, _session, socket) do
+  def mount(%{"profile" => profile} = params, _session, socket) do
     if connected?(socket) do
       PubSub.subscribe(Animina.PubSub, "credits")
+      PubSub.subscribe(Animina.PubSub, "messages")
     end
 
-    {:ok, sender} = Accounts.User.by_username(current_user)
+    sender =
+      if params["current_user"] do
+        {:ok, sender} = Accounts.User.by_username(params["current_user"])
+        sender
+      else
+        socket.assigns.current_user
+      end
+
     {:ok, receiver} = Accounts.User.by_username(profile)
 
     {:ok, messages_between_sender_and_receiver} =
@@ -55,6 +63,8 @@ defmodule AniminaWeb.ChatLive do
             actor: socket.assigns.sender
           )
 
+        PubSub.broadcast(Animina.PubSub, "messages", {:new_message, message})
+
         {:noreply,
          socket
          |> assign(messages: messages_between_sender_and_receiver)
@@ -62,6 +72,33 @@ defmodule AniminaWeb.ChatLive do
 
       {:error, _} ->
         {:noreply, assign(socket, form: socket.assigns.form)}
+    end
+  end
+
+  def handle_info({:new_message, message}, socket) do
+    {:ok, message} = Message.by_id(message.id)
+
+    messages =
+      (socket.assigns.messages ++ message)
+      |> Enum.uniq()
+
+    if message_belongs_to_current_user_or_profile(
+         List.first(message),
+         socket.assigns.sender,
+         socket.assigns.receiver
+       ) do
+      {:noreply, socket |> assign(messages: messages)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  defp message_belongs_to_current_user_or_profile(message, current_user, profile) do
+    if (message.sender_id == current_user.id and message.receiver_id == profile.id) or
+         (message.sender_id == profile.id and message.receiver_id == current_user.id) do
+      true
+    else
+      false
     end
   end
 
@@ -86,7 +123,11 @@ defmodule AniminaWeb.ChatLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="md:h-[90vh] h-[85vh] relative  w-[100%] flex gap-4 flex-col justify-betwen">
+    <div
+      phx-hook="Test"
+      id="test"
+      class="md:h-[90vh] h-[85vh] relative  w-[100%] flex gap-4 flex-col justify-betwen"
+    >
       <.chat_messages_component sender={@sender} receiver={@receiver} messages={@messages} />
       <div class="w-[100%]  absolute bottom-0">
         <.form

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -41,6 +41,7 @@ defmodule AniminaWeb.Router do
       live "/profile/flags/green", FlagsLive, :green
       live "/profile/flags/red", FlagsLive, :red
       live "/profile/about-me", StoryLive, :about_me
+      live "/current_user/messages/:profile", ChatLive, :index
       live "/:current_user/messages/:profile", ChatLive, :index
       live "/:username", ProfileLive
     end


### PR DESCRIPTION
- In this PR , I added the /current_user/messages/:profile route that takes the logged in current user as the sender
- I added PubSub to ensure chats added stream in realtime
- I added small amount of Javascript to ensure when a text is added  , the chat message box scrolls down to the last added text


The messages are now as such


https://github.com/animina-dating/animina/assets/86654131/9cd9273e-f9ef-4bc9-b118-26656db8cfc2


@wintermeyer  , please test it out on your side and advise if it is working well on your side.

