### PR TITLE
Custom action has_been_read for messages , closes #321

### DIFF
--- a/lib/animina/accounts/points.ex
+++ b/lib/animina/accounts/points.ex
@@ -39,4 +39,8 @@ defmodule Animina.Accounts.Points do
     {:ok, date} = Timex.format(date, "{YYYY}-{0M}-{0D}")
     date
   end
+
+  def format_time(time) do
+    NaiveDateTime.from_erl!({{2000, 1, 1}, Time.to_erl(time)}) |> Timex.format!("{h12}:{0m} {am}")
+  end
 end

--- a/lib/animina/accounts/resources/message.ex
+++ b/lib/animina/accounts/resources/message.ex
@@ -39,6 +39,10 @@ defmodule Animina.Accounts.Message do
   actions do
     defaults [:create, :read]
 
+    update :has_been_read do
+      change set_attribute(:read_at, DateTime.utc_now())
+    end
+
     read :by_id do
       argument :id, :uuid do
         allow_nil? false
@@ -73,6 +77,7 @@ defmodule Animina.Accounts.Message do
     define :create
 
     define :by_id, args: [:id]
+    define :has_been_read
 
     define :messages_for_sender_and_receiver, args: [:sender_id, :receiver_id]
   end
@@ -84,6 +89,10 @@ defmodule Animina.Accounts.Message do
 
     policy action(:messages_for_sender_and_receiver) do
       authorize_if Animina.Checks.ReadMessageCheck
+    end
+
+    policy action(:has_been_read) do
+      authorize_if Animina.Checks.UpdateReadAtCheck
     end
   end
 

--- a/lib/animina/checks/update_readat_check.ex
+++ b/lib/animina/checks/update_readat_check.ex
@@ -1,0 +1,18 @@
+defmodule Animina.Checks.UpdateReadAtCheck do
+  @moduledoc """
+  Policy for The Update Message Action That updates the read_at field
+  """
+  use Ash.Policy.SimpleCheck
+
+  def describe(_opts) do
+    "Ensures an actor can only update messages that they are the  receiver of"
+  end
+
+  def match?(actor, params, _opts) do
+    if actor.id == params.changeset.data.receiver_id do
+      true
+    else
+      false
+    end
+  end
+end

--- a/lib/animina_web/components/chat/chat_components.ex
+++ b/lib/animina_web/components/chat/chat_components.ex
@@ -81,10 +81,13 @@ defmodule AniminaWeb.ChatComponents do
           <p>
             You
           </p>
-          <div class="md:w-[300px] w-[250px] bg-blue-500 flex text-white p-2 items-end  rounded-md">
+          <div class="md:w-[300px] w-[250px] bg-blue-500 flex text-white p-1 items-end flex flex-col gap-2  rounded-md">
             <p>
               <%= Markdown.format(@content) %>
             </p>
+            <div class="text-xs px-2 flex justify-start">
+              <%= format_time(@message.created_at) %>
+            </div>
           </div>
         </div>
         <.user_image user={@sender} />
@@ -102,10 +105,15 @@ defmodule AniminaWeb.ChatComponents do
           <p class="dark:text-white">
             <%= @receiver.username %>
           </p>
-          <div class="md:w-[300px w-[250px]   dark:bg-white bg-gray-300 text-black  flex p-2 items-end rounded-md">
+          <div class="md:w-[300px w-[250px]   dark:bg-white bg-gray-300 text-black   flex flex-col gap-2 justify-between p-1 items-end rounded-md">
             <p>
               <%= Markdown.format(@content) %>
             </p>
+
+            <div :if={@message.read_at != nil} class="text-xs px-2 flex justify-end">
+              <%= format_time(@message.read_at) %>
+              <.already_read_ticks />
+            </div>
           </div>
         </div>
       </div>
@@ -147,5 +155,45 @@ defmodule AniminaWeb.ChatComponents do
       </svg>
     <% end %>
     """
+  end
+
+  def already_read_ticks(assigns) do
+    ~H"""
+    <div class="flex  gap-0 relative">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="green"
+        aria-hidden="true"
+        width="12"
+        height="12"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+          clip-rule="evenodd"
+        />
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="green"
+        aria-hidden="true"
+        width="12"
+        height="12"
+        class="absolute left-1/2"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
+          clip-rule="evenodd"
+        />
+      </svg>
+    </div>
+    """
+  end
+
+  def format_time(time) do
+    NaiveDateTime.from_erl!({{2000, 1, 1}, Time.to_erl(time)}) |> Timex.format!("{h12}:{0m} {am}")
   end
 end

--- a/lib/animina_web/components/chat/chat_components.ex
+++ b/lib/animina_web/components/chat/chat_components.ex
@@ -85,7 +85,12 @@ defmodule AniminaWeb.ChatComponents do
             <p>
               <%= Markdown.format(@content) %>
             </p>
-            <div class="text-xs px-2 flex justify-start">
+
+            <div :if={@message.read_at != nil} class="text-xs px-2 flex justify-end">
+              <%= format_time(@message.read_at) %>
+              <.already_read_ticks />
+            </div>
+            <div :if={@message.read_at == nil} class="text-xs px-2 flex justify-end">
               <%= format_time(@message.created_at) %>
             </div>
           </div>
@@ -111,8 +116,7 @@ defmodule AniminaWeb.ChatComponents do
             </p>
 
             <div :if={@message.read_at != nil} class="text-xs px-2 flex justify-end">
-              <%= format_time(@message.read_at) %>
-              <.already_read_ticks />
+              <%= format_time(@message.created_at) %>
             </div>
           </div>
         </div>
@@ -163,10 +167,11 @@ defmodule AniminaWeb.ChatComponents do
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
-        fill="green"
+        class="text-green-500"
         aria-hidden="true"
         width="12"
         height="12"
+        fill="#52A35D"
       >
         <path
           fill-rule="evenodd"
@@ -177,11 +182,11 @@ defmodule AniminaWeb.ChatComponents do
       <svg
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 20 20"
-        fill="green"
         aria-hidden="true"
         width="12"
         height="12"
-        class="absolute left-1/2"
+        fill="#52A35D"
+        class="absolute  left-1/2"
       >
         <path
           fill-rule="evenodd"

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -27,6 +27,9 @@ defmodule AniminaWeb.ChatLive do
     {:ok, messages_between_sender_and_receiver} =
       Message.messages_for_sender_and_receiver(sender.id, receiver.id, actor: sender)
 
+    # we make sure that the messages are marked as read when the user visits the chat page
+    update_read_at_messages(messages_between_sender_and_receiver, sender)
+
     socket =
       socket
       |> assign(active_tab: :chat)
@@ -37,6 +40,14 @@ defmodule AniminaWeb.ChatLive do
       |> assign(page_title: gettext("Chat"))
 
     {:ok, socket}
+  end
+
+  defp update_read_at_messages(messages, sender) do
+    Enum.each(messages, fn message ->
+      if message.receiver_id == sender.id and message.read_at == nil do
+        Message.has_been_read(message, actor: sender)
+      end
+    end)
   end
 
   defp create_message_form do

--- a/test/animina/accounts/message_test.exs
+++ b/test/animina/accounts/message_test.exs
@@ -108,6 +108,25 @@ defmodule Animina.Accounts.MessageTest do
                  actor: fifth_user
                )
     end
+
+    test "A user can only change the read_at field of a message that they are the receiver of" do
+      third_user = create_third_user()
+      fourth_user = create_fourth_user()
+      fifth_user = create_fifth_user()
+
+      {:ok, message} =
+        create_message(
+          third_user.id,
+          fourth_user.id,
+          third_user
+        )
+
+      assert {:error, _} =
+               Message.has_been_read(message, actor: fifth_user)
+
+      assert {:ok, _} =
+               Message.has_been_read(message, actor: fourth_user)
+    end
   end
 
   # for this user , other users can send messages to them without needing the user to like that profile


### PR DESCRIPTION
- Custom action called `has_been_read` that adds the read at to the current time.
- On mount for the chat page , we change all the messages that have been unread to read
- For messages a user has sent , they can view the time they sent the message if it has not been read , and if it has been read , the read at timestamp is shown with 2 check marks
- For received messages , they see the time they received them.
![Screenshot 2024-04-23 at 12 45 29](https://github.com/animina-dating/animina/assets/86654131/d33cea2a-3a77-442c-bcfc-fb25639c079e)

