### PR TITLE
Improve HTML Title of the Chat , closes  #323

### DIFF
--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -37,7 +37,7 @@ defmodule AniminaWeb.ChatLive do
       |> assign(:messages, messages_between_sender_and_receiver)
       |> assign(receiver: receiver)
       |> assign(form: create_message_form())
-      |> assign(page_title: gettext("Chat"))
+      |> assign(page_title: "#{sender.username} <-> #{receiver.username} (animina chat)")
 
     {:ok, socket}
   end
@@ -107,7 +107,13 @@ defmodule AniminaWeb.ChatLive do
          socket.assigns.sender,
          socket.assigns.receiver
        ) do
-      {:noreply, socket |> assign(messages: messages)}
+      {:noreply,
+       socket
+       |> assign(
+         page_title:
+           "💬 #{socket.assigns.sender.username} <-> #{socket.assigns.receiver.username} (animina chat)"
+       )
+       |> assign(messages: messages)}
     else
       {:noreply, socket}
     end


### PR DESCRIPTION
- This PR ensures we now have a page title for the chat live as such  `"#{sender.username} <-> #{receiver.username} (animina chat)"` and  "💬 #{socket.assigns.sender.username} <-> #{socket.assigns.receiver.username} (animina chat)" for when there is a new message


![Screenshot 2024-04-24 at 07 02 26](https://github.com/animina-dating/animina/assets/86654131/d31e6c70-b332-4932-a762-9b234f483399)
