### PR TITLE
💬 in the HTML title only if a new message waits , closes #335

### DIFF
--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -97,6 +97,15 @@ defmodule AniminaWeb.ChatLive do
     end
   end
 
+  defp get_page_title(message, sender, receiver) do
+    # if I am the one who has received the new message it should add the chat icon
+    if message.receiver_id == sender.id do
+      "💬 #{sender.username} <-> #{receiver.username} (animina chat)"
+    else
+      "#{sender.username} <-> #{receiver.username} (animina chat)"
+    end
+  end
+
   def handle_info({:new_message, message}, socket) do
     {:ok, message} = Message.by_id(message.id)
 
@@ -111,11 +120,12 @@ defmodule AniminaWeb.ChatLive do
          socket.assigns.sender,
          socket.assigns.receiver
        ) do
+      page_title =
+        get_page_title(List.first(message), socket.assigns.sender, socket.assigns.receiver)
+
       {:noreply,
        socket
-       |> assign(
-         page_title:
-           "💬 #{socket.assigns.sender.username} <-> #{socket.assigns.receiver.username} (animina chat)")
+       |> assign(page_title: page_title)
        |> assign(unread_messages: unread_messages)
        |> assign(number_of_unread_messages: Enum.count(unread_messages))
        |> assign(messages: messages)}


### PR DESCRIPTION
- Hello  @wintermeyer , I am not sure if I understood you well and implimented it as you wanted , kindly watch the video and advise if it so.
- In this case , as a user I will see the  💬 in the HTML title only if I receive a new message not when I send a new one as it was before

https://github.com/animina-dating/animina/assets/86654131/8d685406-f5ae-45b6-832e-3d41c6eb6835

