### PR TITLE
Fixed redirect issue for sign in if current user is present , closes  #341

### DIFF
--- a/lib/animina_web/live/auth_live/user_auth.ex
+++ b/lib/animina_web/live/auth_live/user_auth.ex
@@ -77,7 +77,8 @@ defmodule AniminaWeb.LiveUserAuth do
 
   def on_mount(:live_no_user, _params, _session, socket) do
     if socket.assigns[:current_user] do
-      {:halt, Phoenix.LiveView.redirect(socket, to: ~p"/sign-in")}
+      {:halt,
+       Phoenix.LiveView.redirect(socket, to: ~p"/#{socket.assigns[:current_user].username}")}
     else
       {:cont,
        socket


### PR DESCRIPTION
- Now if the user is logged in and they visit `/sign-in` they are redirected back to their profile

https://github.com/animina-dating/animina/assets/86654131/61da26bc-d35a-4e10-8de3-bdb0cb498c9a

