### PR TITLE
Rate limit for new messages , closes #315

### DIFF
--- a/lib/animina/accounts/resources/message.ex
+++ b/lib/animina/accounts/resources/message.ex
@@ -70,6 +70,26 @@ defmodule Animina.Accounts.Message do
              )
     end
 
+    read :messages_sent_to_a_user_by_sender do
+      argument :sender_id, :uuid do
+        allow_nil? false
+      end
+
+      argument :receiver_id, :uuid do
+        allow_nil? false
+      end
+
+      filter expr(sender_id == ^arg(:sender_id) and receiver_id == ^arg(:receiver_id))
+    end
+
+    read :messages_sent_by_user do
+      argument :sender_id, :uuid do
+        allow_nil? false
+      end
+
+      filter expr(sender_id == ^arg(:sender_id))
+    end
+
     read :unread_messages_for_user do
       argument :user_id, :uuid do
         allow_nil? false
@@ -89,6 +109,9 @@ defmodule Animina.Accounts.Message do
     define :unread_messages_for_user, args: [:user_id]
 
     define :messages_for_sender_and_receiver, args: [:sender_id, :receiver_id]
+    define :messages_sent_to_a_user_by_sender, args: [:sender_id, :receiver_id]
+
+    define :messages_sent_by_user, args: [:sender_id]
   end
 
   policies do


### PR DESCRIPTION
I implimented the following rules .

 - A user can not create more than 10 messages within a minute to an other user.
 - A user can not create more than 20 messages within a minute.
 - A user can not create more than 50 messages within an hour to an other user.
 - A user can not create more than 250 messages on a single day.


I am not sure how to proceed with testing as these are edge cases . Below is the function I am using to check for these rules though which I have tested locally .

```
defp check_messages_within_minutes(messages, minutes, limit) do
    current_time = DateTime.utc_now()

    previous_time = DateTime.add(current_time, -minutes, :minute)

    messages =
      messages
      |> Enum.filter(fn message ->
        DateTime.compare(message.created_at, previous_time) == :gt and
          DateTime.compare(message.created_at, current_time) == :lt
      end)

    if Enum.count(messages) > limit do
      false
    else
      true
    end
  end
```

would love to hear your thoughts @wintermeyer 