### PR TITLE
enable or disable ml features via env variable, closes #368

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,8 @@ NETWORK_MODE=bridge
 # For an installation where the project directory is mounted read-only in a Linux VM:
 VOLUMES_PATH="/home/user/animina-volumes"
 
-
+# To enable machine learning features set to true
+ENABLE_ML_FEATURES=true
 
 # For Emacs:
 # Local Variables:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    
+
     services:
       db:
         image: postgres:13
@@ -21,11 +21,11 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Cache Asdf installation and plugins
         uses: actions/cache@v4
         with:
@@ -34,7 +34,7 @@ jobs:
             ~/.asdf/plugins/*
             ~/.asdf/installs/*
           key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
-      
+
       - name: Install Asdf
         run: |
           if [ ! -d $HOME/.asdf ]; then
@@ -42,7 +42,7 @@ jobs:
             echo -e "\n. $HOME/.asdf/asdf.sh" >> $HOME/.bashrc
             echo -e "\n. $HOME/.asdf/completions/asdf.bash" >> $HOME/.bashrc
           fi
-      
+
       - name: Install Erlang and Elixir from .tool-versions
         run: |
           . $HOME/.asdf/asdf.sh
@@ -54,15 +54,17 @@ jobs:
           asdf global  erlang $erlang_version
           asdf install elixir $elixir_version
           asdf global  elixir $elixir_version
-      
+
       - name: Install dependencies
+        env:
+          ENABLE_ML_FEATURES: true
         run: |
           . $HOME/.asdf/asdf.sh
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
           mix compile
-      
+
       - name: Create and migrate database
         env:
           MIX_ENV: test
@@ -74,7 +76,7 @@ jobs:
           . $HOME/.asdf/asdf.sh
           mix ecto.create
           mix ecto.migrate
-      
+
       - name: Run tests
         env:
           MIX_ENV: test
@@ -82,15 +84,15 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: postgres
           PGDATABASE: animina_test
+          ENABLE_ML_FEATURES: true
         run: |
           . $HOME/.asdf/asdf.sh
           mix test
-      
+
       - name: Run Credo
         run: |
           . $HOME/.asdf/asdf.sh
           mix credo --strict
-
 
 # For Emacs:
 # Local Variables:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ To start your Phoenix server:
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
+## Enable Machine Learning features and servings
+
+To enable running ML features:
+  * set `ENABLE_ML_FEATURES` environment variable to true
+  * For example to start the phoenix server in dev mode with ML features run `ENABLE_ML_FEATURES=true iex -S mix phx.server`
+
 ## Thoughts about the Frontend
 
 Keep it simple. Let's not use JavaScript everywhere. Better ask sw@wintermeyer-consulting.de first 

--- a/lib/animina/actions/process_photo.ex
+++ b/lib/animina/actions/process_photo.ex
@@ -10,51 +10,53 @@ defmodule Animina.Actions.ProcessPhoto do
 
   @impl true
   def update(changeset, _, _) do
-    # Update photo state to pending_review
-    changeset.data
-    |> Ash.Changeset.for_update(:review, %{})
-    |> Accounts.update(authorize?: false)
-    |> case do
-      {:ok, photo} ->
-        # Fetch and read the photo file
-        dest = get_upload_dir(photo.filename)
-        image = StbImage.read_file!(dest)
-        # Classify image using the Nx.Serving
-        output =
-          Nx.Serving.batched_run(NsfwDetectionServing, image)
+    with false <- is_nil(System.get_env("ENABLE_ML_FEATURES")),
+         {:ok, photo} <-
+           changeset.data
+           |> Ash.Changeset.for_update(:review, %{})
+           |> Accounts.update(authorize?: false) do
+      # Fetch and read the photo file
+      dest = get_upload_dir(photo.filename)
+      image = StbImage.read_file!(dest)
+      # Classify image using the Nx.Serving
+      output =
+        Nx.Serving.batched_run(NsfwDetectionServing, image)
 
-        # Get the normal label score
-        normal_label_score =
-          Enum.filter(output.predictions, fn prediction -> prediction.label == "normal" end)
-          |> Enum.at(0)
-          |> Map.get(:score)
+      # Get the normal label score
+      normal_label_score =
+        Enum.filter(output.predictions, fn prediction -> prediction.label == "normal" end)
+        |> Enum.at(0)
+        |> Map.get(:score)
 
-        # Get the nsfw label score
-        nsfw_label_score =
-          Enum.filter(output.predictions, fn prediction -> prediction.label == "nsfw" end)
-          |> Enum.at(0)
-          |> Map.get(:score)
+      # Get the nsfw label score
+      nsfw_label_score =
+        Enum.filter(output.predictions, fn prediction -> prediction.label == "nsfw" end)
+        |> Enum.at(0)
+        |> Map.get(:score)
 
-        # Approve normal photo, reject otherwise
-        if normal_label_score > nsfw_label_score do
-          photo
-          |> Ash.Changeset.for_update(:approve, %{})
-          |> Accounts.update(authorize?: false)
-        else
-          photo
-          |> Ash.Changeset.for_update(:reject, %{})
-          |> Accounts.update(authorize?: false)
-        end
+      # Approve normal photo, reject otherwise
+      if normal_label_score > nsfw_label_score do
+        photo
+        |> Ash.Changeset.for_update(:approve, %{})
+        |> Accounts.update(authorize?: false)
+      else
+        photo
+        |> Ash.Changeset.for_update(:reject, %{})
+        |> Accounts.update(authorize?: false)
+      end
 
-      {:eror, error} ->
+      {:ok, changeset.data}
+    else
+      true ->
+        {:ok, changeset.data}
+
+      {:error, error} ->
         Logger.info(
           "[#{__MODULE__}] failed to update photo status to in_review. Error #{inspect(error)}"
         )
 
         {:error, changeset.data}
     end
-
-    {:ok, changeset.data}
   end
 
   defp get_upload_dir(filename) do

--- a/lib/animina/application.ex
+++ b/lib/animina/application.ex
@@ -24,10 +24,6 @@ defmodule Animina.Application do
       # Start the Finch HTTP client for sending emails
       {Finch, name: Animina.Finch},
       {Animina.GenServers.ProfileViewCredits, []},
-      {Nx.Serving,
-       name: NsfwDetectionServing,
-       serving: Servings.NsfwDetectionServing.serving(),
-       batch_timeout: 100},
 
       # Start a worker by calling: Animina.Worker.start_link(arg)
       # {Animina.Worker, arg},
@@ -35,6 +31,19 @@ defmodule Animina.Application do
       AniminaWeb.Endpoint,
       {AshAuthentication.Supervisor, otp_app: :animina}
     ]
+
+    children =
+      if is_nil(System.get_env("ENABLE_ML_FEATURES")) do
+        children
+      else
+        children ++
+          [
+            {Nx.Serving,
+             name: NsfwDetectionServing,
+             serving: Servings.NsfwDetectionServing.serving(),
+             batch_timeout: 100}
+          ]
+      end
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,9 @@ defmodule Animina.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
+  # Enable dependency conditionally
+  def dep_enabled?(key), do: not is_nil(System.get_env(key))
+
   # Specifies your project dependencies.
   #
   # Type `mix help deps` for examples and options.
@@ -68,9 +71,9 @@ defmodule Animina.MixProject do
       {:mdex, "~> 0.1"},
       {:html_sanitize_ex, "~> 1.4"},
       {:timex, "~> 3.0"},
-      {:bumblebee, "~> 0.5.3"},
-      {:exla, ">= 0.0.0"},
-      {:stb_image, "~> 0.6.3"},
+      {:bumblebee, "~> 0.5.3", optional: dep_enabled?("ENABLE_ML_FEATURES")},
+      {:exla, ">= 0.0.0", optional: dep_enabled?("ENABLE_ML_FEATURES")},
+      {:stb_image, "~> 0.6.3", optional: dep_enabled?("ENABLE_ML_FEATURES")},
       {:oban, "~> 2.17"},
       {:ash_oban, "~> 0.2.2"}
     ]

--- a/test/animina/photos/nsfw_test.exs
+++ b/test/animina/photos/nsfw_test.exs
@@ -5,11 +5,15 @@ defmodule Animina.Photos.NsfwTest do
 
   describe "Tests for Nsfw photos detection using AI" do
     setup do
-      [
-        serving: load_serving(),
-        nsfw_photo: load_nsfw_photo(),
-        sfw_photo: load_sfw_photo()
-      ]
+      if is_nil(System.get_env("ENABLE_ML_FEATURES")) do
+        {:ok, skip: true}
+      else
+        [
+          serving: load_serving(),
+          nsfw_photo: load_nsfw_photo(),
+          sfw_photo: load_sfw_photo()
+        ]
+      end
     end
 
     test "The following photo is not safe for work.", %{


### PR DESCRIPTION
This adds the possibility to enable or disable ML features via an environment variable. when `ENABLE_ML_FEATURES` is set , the ML deps and servings are enabled. If not set ML features are disabled and deps are not compiled.