### PR TITLE
fixed registration test to ensure we check if category exists first

### DIFF
--- a/test/animina/accounts/registration_test.exs
+++ b/test/animina/accounts/registration_test.exs
@@ -135,9 +135,14 @@ defmodule Animina.Accounts.RegistrationTest do
   end
 
   defp create_category do
-    {:ok, category} = Category.create(%{name: "Drinks"})
+    case Category.by_name("Drinks") do
+      {:ok, category} ->
+        category
 
-    category
+      _ ->
+        {:ok, category} = Category.create(%{name: "Drinks"})
+        category
+    end
   end
 
   defp create_flags(category) do


### PR DESCRIPTION
@wintermeyer  , This PR ensures that we first check if the category exists and if it does we use that  , if it does not , we then create it .