### PR TITLE
Fixed optional nx config , closes #373

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,9 +6,10 @@
 
 # General application configuration
 import Config
-
+if System.get_env("ENABLE_ML_FEATURES") do
 # Configures nx default backend
 config :nx, default_backend: EXLA.Backend
+end
 
 # Configures Oban jobs
 config :animina, Oban,


### PR DESCRIPTION
- In this PR I ensured the nx config is optional in the config.exs with 
```
if System.get_env("ENABLE_ML_FEATURES") do
# Configures nx default backend
config :nx, default_backend: EXLA.Backend
end
```

which removes the problem when running the server

