### PR TITLE
remove function find_user_flag_for_a_flag/2 is unused  , closes #394

### DIFF
--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -170,9 +170,6 @@ defmodule AniminaWeb.ChatLive do
     end)
   end
 
-  defp find_user_flag_for_a_flag(user_flags, flag) do
-    Enum.find(user_flags, fn x -> x.flag_id == flag.id end)
-  end
 
   defp get_reaction_for_sender_and_receiver(user_id, current_user_id) do
     {:ok, reaction} =

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -170,7 +170,6 @@ defmodule AniminaWeb.ChatLive do
     end)
   end
 
-
   defp get_reaction_for_sender_and_receiver(user_id, current_user_id) do
     {:ok, reaction} =
       Reaction.by_sender_and_receiver_id(user_id, current_user_id)


### PR DESCRIPTION
- I removed the unused function  `find_user_flag_for_a_flag/2`