### PR TITLE
Feature/add pubsub to resource actions , closes #393

### DIFF
--- a/lib/animina/accounts/resources/credit.ex
+++ b/lib/animina/accounts/resources/credit.ex
@@ -3,8 +3,8 @@ defmodule Animina.Accounts.Credit do
   This is the Credit module which we use to manage points.
   """
 
-  alias Phoenix.PubSub
   alias Animina.Accounts.User
+  alias Phoenix.PubSub
 
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer

--- a/lib/animina/accounts/resources/credit.ex
+++ b/lib/animina/accounts/resources/credit.ex
@@ -3,6 +3,9 @@ defmodule Animina.Accounts.Credit do
   This is the Credit module which we use to manage points.
   """
 
+  alias Phoenix.PubSub
+  alias Animina.Accounts.User
+
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer
 
@@ -36,6 +39,20 @@ defmodule Animina.Accounts.Credit do
     define :read
     define :create
     define :by_id, get_by: [:id], action: :read
+  end
+
+  changes do
+    change after_action(fn changeset, record ->
+             username =
+               User.by_id!(record.user_id)
+               |> Map.get(:username)
+               |> Ash.CiString.value()
+
+             PubSub.broadcast(Animina.PubSub, username, {:user, User.by_id!(record.user_id)})
+
+             {:ok, record}
+           end),
+           on: [:create]
   end
 
   postgres do

--- a/lib/animina/accounts/resources/message.ex
+++ b/lib/animina/accounts/resources/message.ex
@@ -2,6 +2,10 @@ defmodule Animina.Accounts.Message do
   @moduledoc """
   This is the Message module which we use to manage messages between users.
   """
+
+  alias Phoenix.PubSub
+  alias Animina.Accounts.User
+
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer,
     authorizers: Ash.Policy.Authorizer
@@ -116,6 +120,15 @@ defmodule Animina.Accounts.Message do
     define :messages_sent_to_a_user_by_sender, args: [:sender_id, :receiver_id]
 
     define :messages_sent_by_user, args: [:sender_id]
+  end
+
+  changes do
+    change after_action(fn changeset, record ->
+             PubSub.broadcast(Animina.PubSub, "messages", {:new_message, record})
+
+             {:ok, record}
+           end),
+           on: [:create]
   end
 
   policies do

--- a/lib/animina/accounts/resources/message.ex
+++ b/lib/animina/accounts/resources/message.ex
@@ -3,8 +3,8 @@ defmodule Animina.Accounts.Message do
   This is the Message module which we use to manage messages between users.
   """
 
-  alias Phoenix.PubSub
   alias Animina.Accounts.User
+  alias Phoenix.PubSub
 
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer,

--- a/lib/animina/accounts/resources/reaction.ex
+++ b/lib/animina/accounts/resources/reaction.ex
@@ -3,8 +3,8 @@ defmodule Animina.Accounts.Reaction do
   This is the Reaction module which we use to manage likes, block, etc.
   """
 
-  alias Phoenix.PubSub
   alias Animina.Accounts.User
+  alias Phoenix.PubSub
 
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer,

--- a/lib/animina/accounts/resources/user_role.ex
+++ b/lib/animina/accounts/resources/user_role.ex
@@ -3,8 +3,8 @@ defmodule Animina.Accounts.UserRole do
   This is the User Role module which we use to manage user roles.
   """
 
-  alias Phoenix.PubSub
   alias Animina.Accounts.User
+  alias Phoenix.PubSub
 
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer,


### PR DESCRIPTION
This PR added the following

- [x] Send broadcast if a create action is called in the `Credit` resource.
- [x] Send broadcast if a create or delete action is called in the `Reaction` resource (for this , publish to both the receiver and sender)
- [x] Send broadcast when a create action is called in the `UserRole` resource .
- [x] Send broadcast when a create action is called in the `UserFlags`  resource