### PR TITLE
Feature/fix anonymous user profile visit , closes #433

### DIFF
--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -103,6 +103,14 @@ defmodule Animina.Accounts.BasicUser do
 
   actions do
     defaults [:create, :read]
+
+
+      read :custom_sign_in do
+        argument :username_or_email, :string, allow_nil?: false
+        argument :password, :string, allow_nil?: false, sensitive?: true
+        prepare  Animina.MyCustomSignInPreparation
+      end
+
   end
 
   code_interface do
@@ -110,6 +118,7 @@ defmodule Animina.Accounts.BasicUser do
     define :read
     define :create
     define :by_id, get_by: [:id], action: :read
+    define :custom_sign_in , get?: true
   end
 
   aggregates do

--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -104,13 +104,11 @@ defmodule Animina.Accounts.BasicUser do
   actions do
     defaults [:create, :read]
 
-
-      read :custom_sign_in do
-        argument :username_or_email, :string, allow_nil?: false
-        argument :password, :string, allow_nil?: false, sensitive?: true
-        prepare  Animina.MyCustomSignInPreparation
-      end
-
+    read :custom_sign_in do
+      argument :username_or_email, :string, allow_nil?: false
+      argument :password, :string, allow_nil?: false, sensitive?: true
+      prepare Animina.MyCustomSignInPreparation
+    end
   end
 
   code_interface do
@@ -118,7 +116,7 @@ defmodule Animina.Accounts.BasicUser do
     define :read
     define :create
     define :by_id, get_by: [:id], action: :read
-    define :custom_sign_in , get?: true
+    define :custom_sign_in, get?: true
   end
 
   aggregates do
@@ -144,6 +142,7 @@ defmodule Animina.Accounts.BasicUser do
 
         register_action_accept([
           :email,
+          :username,
           :name,
           :zip_code,
           :birthday,
@@ -155,8 +154,6 @@ defmodule Animina.Accounts.BasicUser do
           :occupation
         ])
       end
-
-
     end
 
     tokens do

--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -124,16 +124,31 @@ defmodule Animina.Accounts.BasicUser do
     prepare build(load: [:age, :credit_points])
   end
 
-
-  
-
   authentication do
     api Accounts
 
     strategies do
-      password :password do
-        identity_field :username
+      password :email_and_password do
         identity_field :email
+        sign_in_tokens_enabled? true
+        confirmation_required?(false)
+
+        register_action_accept([
+          :username,
+          :name,
+          :zip_code,
+          :birthday,
+          :height,
+          :gender,
+          :mobile_phone,
+          :language,
+          :legal_terms_accepted,
+          :occupation
+        ])
+      end
+
+      password :username_and_password do
+        identity_field :username
         sign_in_tokens_enabled? true
         confirmation_required?(false)
 

--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -137,13 +137,13 @@ defmodule Animina.Accounts.BasicUser do
     api Accounts
 
     strategies do
-      password :email_and_password do
+      password :password do
         identity_field :email
         sign_in_tokens_enabled? true
         confirmation_required?(false)
 
         register_action_accept([
-          :username,
+          :email,
           :name,
           :zip_code,
           :birthday,
@@ -156,24 +156,7 @@ defmodule Animina.Accounts.BasicUser do
         ])
       end
 
-      password :username_and_password do
-        identity_field :username
-        sign_in_tokens_enabled? true
-        confirmation_required?(false)
 
-        register_action_accept([
-          :username,
-          :name,
-          :zip_code,
-          :birthday,
-          :height,
-          :gender,
-          :mobile_phone,
-          :language,
-          :legal_terms_accepted,
-          :occupation
-        ])
-      end
     end
 
     tokens do

--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -124,11 +124,15 @@ defmodule Animina.Accounts.BasicUser do
     prepare build(load: [:age, :credit_points])
   end
 
+
+  
+
   authentication do
     api Accounts
 
     strategies do
       password :password do
+        identity_field :username
         identity_field :email
         sign_in_tokens_enabled? true
         confirmation_required?(false)

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -239,10 +239,27 @@ defmodule Animina.Accounts.User do
     api Accounts
 
     strategies do
-      password :password do
+      password :email_and_password do
+        identity_field :email
+        sign_in_tokens_enabled? true
+        confirmation_required?(false)
 
+        register_action_accept([
+          :username,
+          :name,
+          :zip_code,
+          :birthday,
+          :height,
+          :gender,
+          :mobile_phone,
+          :language,
+          :legal_terms_accepted,
+          :occupation
+        ])
+      end
+
+      password :username_and_password do
         identity_field :username
-        
         sign_in_tokens_enabled? true
         confirmation_required?(false)
 

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -162,10 +162,11 @@ defmodule Animina.Accounts.User do
     update :update_last_registration_page_visited do
       accept [:last_registration_page_visited]
     end
+
     read :custom_sign_in do
       argument :username_or_email, :string, allow_nil?: false
       argument :password, :string, allow_nil?: false, sensitive?: true
-      prepare  Animina.MyCustomSignInPreparation
+      prepare Animina.MyCustomSignInPreparation
     end
 
     read :by_username_as_an_actor do
@@ -251,6 +252,7 @@ defmodule Animina.Accounts.User do
         confirmation_required?(false)
 
         register_action_accept([
+          :email,
           :username,
           :name,
           :zip_code,
@@ -263,8 +265,6 @@ defmodule Animina.Accounts.User do
           :occupation
         ])
       end
-
-
     end
 
     tokens do

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -245,7 +245,7 @@ defmodule Animina.Accounts.User do
     api Accounts
 
     strategies do
-      password :email_and_password do
+      password :password do
         identity_field :email
         sign_in_tokens_enabled? true
         confirmation_required?(false)
@@ -264,24 +264,7 @@ defmodule Animina.Accounts.User do
         ])
       end
 
-      password :username_and_password do
-        identity_field :username
-        sign_in_tokens_enabled? true
-        confirmation_required?(false)
 
-        register_action_accept([
-          :username,
-          :name,
-          :zip_code,
-          :birthday,
-          :height,
-          :gender,
-          :mobile_phone,
-          :language,
-          :legal_terms_accepted,
-          :occupation
-        ])
-      end
     end
 
     tokens do

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -240,7 +240,9 @@ defmodule Animina.Accounts.User do
 
     strategies do
       password :password do
-        identity_field :email
+
+        identity_field :username
+        
         sign_in_tokens_enabled? true
         confirmation_required?(false)
 

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -162,6 +162,11 @@ defmodule Animina.Accounts.User do
     update :update_last_registration_page_visited do
       accept [:last_registration_page_visited]
     end
+    read :custom_sign_in do
+      argument :username_or_email, :string, allow_nil?: false
+      argument :password, :string, allow_nil?: false, sensitive?: true
+      prepare  Animina.MyCustomSignInPreparation
+    end
 
     read :by_username_as_an_actor do
       argument :username, :ci_string do
@@ -184,6 +189,7 @@ defmodule Animina.Accounts.User do
     define :by_id, get_by: [:id], action: :read
     define :by_email, get_by: [:email], action: :read
     define :by_username_as_an_actor, args: [:username]
+    define :custom_sign_in, get?: true
   end
 
   calculations do

--- a/lib/animina/accounts/secrets.ex
+++ b/lib/animina/accounts/secrets.ex
@@ -14,4 +14,14 @@ defmodule Animina.Accounts.Secrets do
         :error
     end
   end
+
+  def secret_for([:authentication, :tokens, :signing_secret], Animina.Accounts.BasicUser, _) do
+    case Application.fetch_env(:animina, AniminaWeb.Endpoint) do
+      {:ok, endpoint_config} ->
+        Keyword.fetch(endpoint_config, :secret_key_base)
+
+      :error ->
+        :error
+    end
+  end
 end

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -15,11 +15,11 @@ defmodule Animina.Checks.ReadProfileCheck do
     check_if_user_can_view_profile(actor, params, params.query.arguments)
   end
 
-  defp check_if_user_can_view_profile(_actor, _params , %{}) do
+  defp check_if_user_can_view_profile(_actor, _params, %{}) do
     true
   end
 
-  defp check_if_user_can_view_profile(actor, params , _) do
+  defp check_if_user_can_view_profile(actor, params, _) do
     case User.by_username(params.query.arguments.username) do
       {:ok, profile} ->
         if actor.username == profile.username || profile.is_private == false do

--- a/lib/animina/checks/read_user_role_check.ex
+++ b/lib/animina/checks/read_user_role_check.ex
@@ -3,6 +3,7 @@ defmodule Animina.Checks.ReadUserRoleCheck do
   Policy for The Reading of User Roles
   """
   use Ash.Policy.SimpleCheck
+
   def describe(_opts) do
     "Read User Role Check"
   end

--- a/lib/animina/custom_sign_in_preparation.ex
+++ b/lib/animina/custom_sign_in_preparation.ex
@@ -1,0 +1,109 @@
+defmodule Animina.MyCustomSignInPreparation do
+  @moduledoc """
+  Prepare a query for sign in
+
+  This preparation performs two jobs, one before the query executes and one
+  after.
+
+  Firstly, it constrains the query to match the identity field passed to the
+  action.
+
+  Secondly, it validates the supplied password using the configured hash
+  provider, and if correct allows the record to be returned, otherwise returns
+  an authentication failed error.
+  """
+  use Ash.Resource.Preparation
+  alias AshAuthentication.{Errors.AuthenticationFailed, Info, Jwt}
+  alias Ash.{Error.Unknown, Query, Resource.Preparation}
+  require Ash.Query
+
+  @doc false
+  @impl true
+  @spec prepare(Query.t(), keyword, Preparation.Context.t()) :: Query.t()
+  def prepare(query, options, context) do
+    # {:ok, strategy} = Info.find_strategy(query, context, options)
+    # identity_field = strategy.identity_field
+    # identity = Query.get_argument(query, identity_field)
+if  query.arguments != %{} && query.arguments.password && query.arguments.username_or_email do
+    password =
+      query.arguments.password
+
+
+    query
+    |> Query.filter(
+      email == ^query.arguments.username_or_email or
+        username == ^query.arguments.username_or_email
+    )
+    |> Query.before_action(fn query ->
+      Ash.Query.ensure_selected(query, :hashed_password)
+    end)
+    |> Query.after_action(fn
+      query, [record] when is_binary(:erlang.map_get(:hashed_password, record)) ->
+        password = query.arguments.password
+
+        if Bcrypt.verify_pass(password, Map.get(record, :hashed_password)) do
+          {:ok,
+           [
+             maybe_generate_token(
+               query.context[:token_type] || :user,
+               record
+             )
+           ]}
+        else
+          {:error,
+           AuthenticationFailed.exception(
+             query: query,
+             caused_by: %{
+               module: __MODULE__,
+               action: query.action,
+               resource: query.resource,
+               message: "Password is not valid"
+             }
+           )}
+        end
+    end)
+  else
+    query
+  end
+  end
+
+  defp check_sign_in_token_configuration(query, strategy)
+       when query.context.token_type == :sign_in and not strategy.sign_in_tokens_enabled? do
+    Query.add_error(
+      query,
+      Unknown.exception(
+        message: """
+        Invalid configuration detected. A sign in token was requested for the #{strategy.name} strategy on #{inspect(query.resource)}, but that strategy
+        does not support sign in tokens. See `sign_in_tokens_enabled?` for more.
+        """
+      )
+    )
+  end
+
+  defp check_sign_in_token_configuration(query, _) do
+    query
+  end
+
+  defp maybe_generate_token(purpose, record) when purpose in [:user, :sign_in] do
+    if AshAuthentication.Info.authentication_tokens_enabled?(record.__struct__) do
+
+      generate_token(purpose, record)
+    else
+      record
+    end
+  end
+
+  defp generate_token(purpose, record)
+       when purpose == :sign_in do
+    {:ok, token, _claims} =
+      Jwt.token_for_user(record, %{"purpose" => to_string(purpose)}, token_lifetime: 60)
+
+    Ash.Resource.put_metadata(record, :token, token)
+  end
+
+  defp generate_token(purpose, record) do
+    {:ok, token, _claims} =  Jwt.token_for_user(record, %{"purpose" => to_string(purpose)})
+
+    Ash.Resource.put_metadata(record, :token, token)
+  end
+end

--- a/lib/animina/validations/bad_username.ex
+++ b/lib/animina/validations/bad_username.ex
@@ -21,10 +21,15 @@ defmodule Animina.Validations.BadUsername do
 
     bad_usernames = ["my", "current_user"]
 
-    if username && Ash.CiString.value(username) in bad_usernames do
+    if username &&
+         (Ash.CiString.value(username) in bad_usernames or has_at?(Ash.CiString.value(username))) do
       {:error, field: :username, message: "This is a bad username"}
     else
       :ok
     end
+  end
+
+  def has_at?(string) do
+    String.contains?(string, "@")
   end
 end

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -83,6 +83,50 @@ defmodule AniminaWeb.AuthController do
     |> redirect(to: "/")
   end
 
+
+  def sign_in(conn, params) do
+   case User.custom_sign_in(%{
+      "username_or_email" => params["user"]["username_or_email"],
+      "password" => params["user"]["password"]
+    }) do
+      {:ok , user} ->
+        return_to =
+        case Map.get(conn.query_params, "redirect_to") do
+          nil ->
+            get_session(conn, :return_to) || redirect_url(user)
+
+          path ->
+            path
+        end
+
+
+
+
+
+
+
+
+
+      get_actions_to_perform(conn.query_params, user)
+
+      conn
+      |> delete_session(:return_to)
+      |> store_in_session(user)
+      |> assign(:current_user, user)
+      |> redirect(to: return_to)
+      _ ->
+        conn
+        |> put_flash(
+          :error,
+          gettext("Username or password is incorrect")
+        )
+        |> redirect(to: "/sign-in")
+    end
+
+  end
+
+
+
   def sign_out(conn, _params) do
     return_to = get_session(conn, :return_to) || ~p"/sign-in"
 

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -9,6 +9,7 @@ defmodule AniminaWeb.AuthController do
   alias AshAuthentication.TokenResource
 
   def success(conn, _activity, user, _token) do
+    IO.inspect user
     return_to =
       case Map.get(conn.query_params, "redirect_to") do
         nil ->
@@ -53,6 +54,8 @@ defmodule AniminaWeb.AuthController do
         {:email_and_password, :sign_in},
         %AshAuthentication.Errors.AuthenticationFailed{} = reason
       ) do
+
+        IO.inspect reason
     conn
     |> assign(:errors, reason)
     |> put_flash(

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -51,11 +51,11 @@ defmodule AniminaWeb.AuthController do
 
   def failure(
         conn,
-        {:email_and_password, :sign_in},
+        {:password, :sign_in},
         %AshAuthentication.Errors.AuthenticationFailed{} = reason
       ) do
 
-        IO.inspect reason
+       
     conn
     |> assign(:errors, reason)
     |> put_flash(
@@ -67,7 +67,7 @@ defmodule AniminaWeb.AuthController do
 
   def failure(
         conn,
-        {:email_and_password, :register},
+        {:password, :register},
         reason
       ) do
     conn

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -50,7 +50,7 @@ defmodule AniminaWeb.AuthController do
 
   def failure(
         conn,
-        {:password, :sign_in},
+        {:email_and_password, :sign_in},
         %AshAuthentication.Errors.AuthenticationFailed{} = reason
       ) do
     conn
@@ -64,7 +64,7 @@ defmodule AniminaWeb.AuthController do
 
   def failure(
         conn,
-        {:password, :register},
+        {:email_and_password, :register},
         reason
       ) do
     conn

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -7,6 +7,7 @@ defmodule AniminaWeb.RootLive do
   alias AshPhoenix.Form
   alias Phoenix.PubSub
 
+
   @impl true
   def mount(_params, %{"language" => language} = session, socket) do
     current_user = Registration.get_current_user(session)
@@ -57,7 +58,7 @@ defmodule AniminaWeb.RootLive do
     |> assign(:action, get_link("/auth/user/email_and_password/sign_in/", params))
     |> assign(
       :form,
-      Form.for_action(BasicUser, :sign_in_with_email_and_password, api: Accounts, as: "user")
+      Form.for_action(BasicUser, :custom_sign_in, api: Accounts, as: "user")
     )
   end
 
@@ -70,17 +71,38 @@ defmodule AniminaWeb.RootLive do
 
   @impl true
   def handle_event("submit", %{"user" => user}, socket) do
-    form = Form.validate(socket.assigns.form, user)
+    form =  Form.validate(socket.assigns.form,  user)
+    #   {:ok , user} ->
+    #     user = List.first(user)
+    #     PhoenixLiveSession.put_session(socket, "current_user", user)
+    #     IO.inspect user
+    #     {:noreply, socket
 
-    IO.inspect(form)
+    #     |> redirect(to: "/my/potential-partner")}
 
-    socket =
-      socket
-      |> assign(:form, form)
-      |> assign(:errors, Form.errors(form))
-      |> assign(:trigger_action, form.valid?)
+    #   {:error, form} ->
+    #     {:noreply, socket |> assign(form: form) |> assign(errors: Form.errors(form)) |> put_flash(:error, gettext("Please correct the errors below"))}
 
-    {:noreply, socket}
+
+    # end
+
+
+
+    # socket =
+    #   socket
+    #   |> assign(:form, form)
+    #   |> assign(:errors, Form.errors(form))
+    #   |> assign(:trigger_action, form.valid?)
+
+    # {:noreply, socket}
+  end
+
+
+  defp store_in_session(socket, user) do
+    socket
+    |> assign(:current_user, user)
+    |> assign(:errors, [])
+    |> store_in_session(user)
   end
 
   @impl true
@@ -530,22 +552,22 @@ defmodule AniminaWeb.RootLive do
           >
             <%= gettext("E-mail address") %>
           </label>
-          <div phx-feedback-for={f[:email].name} class="mt-2">
-            <%= text_input(f, :email,
+          <div phx-feedback-for={f[:username_or_email].name} class="mt-2">
+            <%= text_input(f, :username_or_email,
               class:
                 "block w-full rounded-md border-0 py-1.5 text-gray-900 dark:bg-gray-700 dark:text-white  shadow-sm ring-1 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:text-sm  phx-no-feedback:ring-gray-300 phx-no-feedback:focus:ring-indigo-600 sm:leading-6 " <>
-                  unless(get_field_errors(f[:email], :email) == [],
+                  unless(get_field_errors(f[:username_or_email], :username_or_email) == [],
                     do: "ring-red-600 focus:ring-red-600",
                     else: "ring-gray-300 focus:ring-indigo-600"
                   ),
               placeholder: gettext("alice@example.net"),
-              value: f[:email].value,
+              value: f[:username_or_email].value,
               required: true,
-              autocomplete: :email,
+              autocomplete: :username_or_email,
               "phx-debounce": "200"
             ) %>
 
-            <.error :for={msg <- get_field_errors(f[:email], :email)}>
+            <.error :for={msg <- get_field_errors(f[:username_or_email], :username_or_email)}>
               <%= gettext("E-mail address") <> " " <> msg %>
             </.error>
           </div>

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -72,6 +72,7 @@ defmodule AniminaWeb.RootLive do
   def handle_event("submit", %{"user" => user}, socket) do
     form = Form.validate(socket.assigns.form, user)
 
+    IO.inspect(form)
     socket =
       socket
       |> assign(:form, form)
@@ -528,22 +529,22 @@ defmodule AniminaWeb.RootLive do
           >
             <%= gettext("E-mail address") %>
           </label>
-          <div phx-feedback-for={f[:email].name} class="mt-2">
-            <%= text_input(f, :email,
+          <div phx-feedback-for={f[:username].name} class="mt-2">
+            <%= text_input(f, :username,
               class:
                 "block w-full rounded-md border-0 py-1.5 text-gray-900 dark:bg-gray-700 dark:text-white  shadow-sm ring-1 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:text-sm  phx-no-feedback:ring-gray-300 phx-no-feedback:focus:ring-indigo-600 sm:leading-6 " <>
-                  unless(get_field_errors(f[:email], :email) == [],
+                  unless(get_field_errors(f[:username], :username) == [],
                     do: "ring-red-600 focus:ring-red-600",
                     else: "ring-gray-300 focus:ring-indigo-600"
                   ),
               placeholder: gettext("alice@example.net"),
-              value: f[:email].value,
+              value: f[:username].value,
               required: true,
-              autocomplete: :email,
+              autocomplete: :username,
               "phx-debounce": "200"
             ) %>
 
-            <.error :for={msg <- get_field_errors(f[:email], :email)}>
+            <.error :for={msg <- get_field_errors(f[:username], :username)}>
               <%= gettext("E-mail address") <> " " <> msg %>
             </.error>
           </div>

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -55,7 +55,7 @@ defmodule AniminaWeb.RootLive do
     |> assign(:form_id, "sign-in-form")
     |> assign(:cta, gettext("Sign in"))
     |> assign(:sign_up_link, get_link("/", params))
-    |> assign(:action, get_link("/auth/user/email_and_password/sign_in/", params))
+    |> assign(:action, get_link("/auth/user/sign_in/", params))
     |> assign(
       :form,
       Form.for_action(BasicUser, :custom_sign_in, api: Accounts, as: "user")
@@ -71,20 +71,18 @@ defmodule AniminaWeb.RootLive do
 
   @impl true
   def handle_event("submit", %{"user" => user}, socket) do
-    form =  Form.validate(socket.assigns.form,  user)
-    #   {:ok , user} ->
-    #     user = List.first(user)
-    #     PhoenixLiveSession.put_session(socket, "current_user", user)
-    #     IO.inspect user
-    #     {:noreply, socket
+    form = Form.validate(socket.assigns.form,  user)
+    IO.inspect form
 
-    #     |> redirect(to: "/my/potential-partner")}
-
-    #   {:error, form} ->
-    #     {:noreply, socket |> assign(form: form) |> assign(errors: Form.errors(form)) |> put_flash(:error, gettext("Please correct the errors below"))}
+        {:noreply,  socket
+          |> assign(:form, form)
+          |> assign(:errors, Form.errors(form))
+          |> assign(:trigger_action, form.valid?)}
 
 
-    # end
+
+
+
 
 
 

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -45,7 +45,7 @@ defmodule AniminaWeb.RootLive do
     |> assign(:hidden_points, 100)
     |> assign(
       :form,
-      Form.for_create(BasicUser, :register_with_password, api: Accounts, as: "user")
+      Form.for_create(BasicUser, :register_with_username_and_password, api: Accounts, as: "user")
     )
   end
 
@@ -54,10 +54,10 @@ defmodule AniminaWeb.RootLive do
     |> assign(:form_id, "sign-in-form")
     |> assign(:cta, gettext("Sign in"))
     |> assign(:sign_up_link, get_link("/", params))
-    |> assign(:action, get_link("/auth/user/password/sign_in/", params))
+    |> assign(:action, get_link("/auth/user/email_and_password/sign_in/", params))
     |> assign(
       :form,
-      Form.for_action(BasicUser, :sign_in_with_password, api: Accounts, as: "user")
+      Form.for_action(BasicUser, :sign_in_with_email_and_password, api: Accounts, as: "user")
     )
   end
 
@@ -73,6 +73,7 @@ defmodule AniminaWeb.RootLive do
     form = Form.validate(socket.assigns.form, user)
 
     IO.inspect(form)
+
     socket =
       socket
       |> assign(:form, form)
@@ -529,22 +530,22 @@ defmodule AniminaWeb.RootLive do
           >
             <%= gettext("E-mail address") %>
           </label>
-          <div phx-feedback-for={f[:username].name} class="mt-2">
-            <%= text_input(f, :username,
+          <div phx-feedback-for={f[:email].name} class="mt-2">
+            <%= text_input(f, :email,
               class:
                 "block w-full rounded-md border-0 py-1.5 text-gray-900 dark:bg-gray-700 dark:text-white  shadow-sm ring-1 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:text-sm  phx-no-feedback:ring-gray-300 phx-no-feedback:focus:ring-indigo-600 sm:leading-6 " <>
-                  unless(get_field_errors(f[:username], :username) == [],
+                  unless(get_field_errors(f[:email], :email) == [],
                     do: "ring-red-600 focus:ring-red-600",
                     else: "ring-gray-300 focus:ring-indigo-600"
                   ),
               placeholder: gettext("alice@example.net"),
-              value: f[:username].value,
+              value: f[:email].value,
               required: true,
-              autocomplete: :username,
+              autocomplete: :email,
               "phx-debounce": "200"
             ) %>
 
-            <.error :for={msg <- get_field_errors(f[:username], :username)}>
+            <.error :for={msg <- get_field_errors(f[:email], :email)}>
               <%= gettext("E-mail address") <> " " <> msg %>
             </.error>
           </div>

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -7,7 +7,6 @@ defmodule AniminaWeb.RootLive do
   alias AshPhoenix.Form
   alias Phoenix.PubSub
 
-
   @impl true
   def mount(_params, %{"language" => language} = session, socket) do
     current_user = Registration.get_current_user(session)
@@ -71,36 +70,13 @@ defmodule AniminaWeb.RootLive do
 
   @impl true
   def handle_event("submit", %{"user" => user}, socket) do
-    form = Form.validate(socket.assigns.form,  user)
-    IO.inspect form
+    form = Form.validate(socket.assigns.form, user)
 
-        {:noreply,  socket
-          |> assign(:form, form)
-          |> assign(:errors, Form.errors(form))
-          |> assign(:trigger_action, form.valid?)}
-
-
-
-
-
-
-
-
-    # socket =
-    #   socket
-    #   |> assign(:form, form)
-    #   |> assign(:errors, Form.errors(form))
-    #   |> assign(:trigger_action, form.valid?)
-
-    # {:noreply, socket}
-  end
-
-
-  defp store_in_session(socket, user) do
-    socket
-    |> assign(:current_user, user)
-    |> assign(:errors, [])
-    |> store_in_session(user)
+    {:noreply,
+     socket
+     |> assign(:form, form)
+     |> assign(:errors, Form.errors(form))
+     |> assign(:trigger_action, form.valid?)}
   end
 
   @impl true

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -46,7 +46,7 @@ defmodule AniminaWeb.RootLive do
     |> assign(:hidden_points, 100)
     |> assign(
       :form,
-      Form.for_create(BasicUser, :register_with_username_and_password, api: Accounts, as: "user")
+      Form.for_create(BasicUser, :register_with_password, api: Accounts, as: "user")
     )
   end
 

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -46,9 +46,7 @@ defmodule AniminaWeb.Router do
       live "/:current_user/messages/:profile", ChatLive, :index
     end
 
-
-
-    post "/auth/user/sign_in/" , AuthController, :sign_in
+    post "/auth/user/sign_in/", AuthController, :sign_in
 
     get "/demo", PageController, :demo
 

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -46,6 +46,10 @@ defmodule AniminaWeb.Router do
       live "/:current_user/messages/:profile", ChatLive, :index
     end
 
+
+
+    post "/auth/user/sign_in/" , AuthController, :sign_in
+
     get "/demo", PageController, :demo
 
     sign_out_route AuthController, "/auth/user/sign-out"

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -46,8 +46,7 @@ defmodule AniminaWeb.ProfileTest do
 
     test "Anonymous Users Cannot view a Public Users Page", %{
       conn: conn,
-      public_user: public_user,
-      public_user_story: public_user_story
+      public_user: public_user
     } do
       {:ok, view, _html} = live(conn, "/#{public_user.username}")
 

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -20,6 +20,21 @@ defmodule AniminaWeb.RootTest do
     legal_terms_accepted: true
   }
 
+  @valid_create_user_attrs %{
+    email: "michael@example.com",
+    username: "MichaelMunavu",
+    name: "Michael",
+    hashed_password: Bcrypt.hash_pwd_salt("MichaelTheEngineer"),
+    birthday: "1950-01-01",
+    height: 180,
+    zip_code: "56068",
+    gender: "male",
+    mobile_phone: "0151-12345678",
+    occupation: "Software Engineer",
+    language: "en",
+    legal_terms_accepted: true
+  }
+
   describe "Tests the Registration flow" do
     test "The registration form is displayed", %{conn: conn} do
       {:ok, view, _html} = live(conn, "/")
@@ -74,6 +89,28 @@ defmodule AniminaWeb.RootTest do
 
       assert Enum.any?(user_roles, fn user_role -> user_role.role.name == :user end)
     end
+
+    test "A user can login with their email and password", %{conn: conn} do
+      {:ok, user} = User.create(@valid_create_user_attrs)
+
+      {:ok, _index_live, html} =
+        conn
+        |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
+        |> live(~p"/my/potential-partner/")
+
+      assert html =~ "Criteria for your new partner"
+    end
+
+    test "A user can login with their username and password", %{conn: conn} do
+      {:ok, user} = User.create(@valid_create_user_attrs)
+
+      {:ok, _index_live, html} =
+        conn
+        |> login_user(%{"username_or_email" => user.username, "password" => @valid_attrs.password})
+        |> live(~p"/my/potential-partner/")
+
+      assert html =~ "Criteria for your new partner"
+    end
   end
 
   defp sign_in_user(conn, attributes) do
@@ -81,6 +118,15 @@ defmodule AniminaWeb.RootTest do
 
     form =
       form(lv, "#basic_user_form", user: attributes)
+
+    submit_form(form, conn)
+  end
+
+  defp login_user(conn, attributes) do
+    {:ok, lv, _html} = live(conn, ~p"/sign-in/")
+
+    form =
+      form(lv, "#basic_user_sign_in_form", user: attributes)
 
     submit_form(form, conn)
   end


### PR DESCRIPTION
- Added a custom read action for signing in via username and email , suggested by   James Harton [Discord Link](https://discord.com/channels/711271361523351632/955933117573652563/1239787561279295550), I also added on the bad username validation to ensure we check that it does not have an `@` .   
- Got inspiration from  [Ash Auth Custom Preparation](https://github.com/team-alembic/ash_authentication/blob/main/lib/ash_authentication/strategies/password/sign_in_preparation.ex)
- I have also included tests for this feature .



https://github.com/animina-dating/animina/assets/86654131/1d004807-d556-4caa-b398-360251bc1633


https://github.com/animina-dating/animina/assets/86654131/1d004807-d556-4caa-b398-360251bc1633




