### PR TITLE
Feature/fix flags in one place bug , closes #405

### DIFF
--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -50,7 +50,7 @@ defmodule AniminaWeb.StoriesComponents do
         <%= if @story.headline.subject == "About me" do %>
           <img
             :if={
-             (@current_user &&  @story.user_id == @current_user.id) ||
+              (@current_user && @story.user_id == @current_user.id) ||
                 @story.photo.state == :approved
             }
             class="object-cover rounded-lg aspect-square"
@@ -59,7 +59,7 @@ defmodule AniminaWeb.StoriesComponents do
 
           <div
             :if={
-              (@current_user &&  @story.user_id != @current_user.id) &&
+              @current_user && @story.user_id != @current_user.id &&
                 @story.photo.state != :approved
             }
             class="bg-gray-200 dark:bg-gray-800 h-[300px] rounded-lg w-full flex items-center justify-center"
@@ -86,7 +86,7 @@ defmodule AniminaWeb.StoriesComponents do
         <% else %>
           <img
             :if={
-              (@current_user &&   @story.user_id == @current_user.id) ||
+              (@current_user && @story.user_id == @current_user.id) ||
                 @story.photo.state == :approved
             }
             class="object-cover rounded-lg"
@@ -95,7 +95,7 @@ defmodule AniminaWeb.StoriesComponents do
 
           <div
             :if={
-              (@current_user &&   @story.user_id != @current_user.id) &&
+              @current_user && @story.user_id != @current_user.id &&
                 @story.photo.state != :approved
             }
             class="bg-gray-200 dark:bg-gray-800 h-[300px] rounded-lg w-full flex items-center justify-center"
@@ -229,7 +229,7 @@ defmodule AniminaWeb.StoriesComponents do
   def story_action_icons(assigns) do
     ~H"""
     <div
-      :if={@current_user && @user.id == @current_user.id}
+      :if={@current_user && @user.id == @current_user.id && @story.headline != nil}
       class="flex justify-end gap-4 pb-4 text-justify text-gray-600 cursor-pointer dark:text-gray-100"
     >
       <.link navigate={"/my/stories/#{@story.id}/edit" }>

--- a/lib/animina_web/live/profile_stories_live.ex
+++ b/lib/animina_web/live/profile_stories_live.ex
@@ -94,9 +94,7 @@ defmodule AniminaWeb.ProfileStoriesLive do
 
             {:noreply,
              socket
-             |> delete_story_by_dom_id(dom_id)
-
-            }
+             |> delete_story_by_dom_id(dom_id)}
 
           _ ->
             {:noreply,
@@ -173,7 +171,11 @@ defmodule AniminaWeb.ProfileStoriesLive do
   defp delete_story_by_dom_id(socket, dom_id) do
     socket
     |> stream_delete_by_dom_id(:stories_and_flags, dom_id)
-    |> stream(:stories_and_flags, fetch_stories_and_flags(socket.assigns.user.id, socket.assigns.language))
+    |> stream(
+      :stories_and_flags,
+      fetch_stories_and_flags(socket.assigns.user.id, socket.assigns.language),
+      reset: true
+    )
   end
 
   defp fetch_flags(user_id, color) do
@@ -212,9 +214,13 @@ defmodule AniminaWeb.ProfileStoriesLive do
     end)
   end
 
+  def group_flags_with_stories([], []), do: []
+  def group_flags_with_stories([], flags), do: chunk_five_flags_if_stories_are_empty(flags)
+  def group_flags_with_stories(stories, []), do: Enum.map(stories, &{[], &1})
+
   def group_flags_with_stories(stories, flags) do
     flags_per_story =
-      if length(stories) > 0 do
+      if length(flags) > 0 do
         div(length(flags), length(stories))
       else
         0
@@ -224,11 +230,14 @@ defmodule AniminaWeb.ProfileStoriesLive do
 
     chunks = chunk(flags, flags_per_story, extra_flags)
 
-    Enum.zip(chunks, stories)
+    Enum.zip(
+      chunks ++ Enum.map(1..(length(stories) - length(chunks)), fn _ -> [] end),
+      stories
+    )
     |> Enum.map(fn {flag_chunk, story} -> {flag_chunk, story} end)
   end
 
-  defp chunk(flags, _count, 0) when length(flags) == 0, do: []
+  defp chunk(flags, _count, 0) when flags == [], do: []
 
   defp chunk(flags, count, extra) do
     if extra > 0 do
@@ -237,6 +246,17 @@ defmodule AniminaWeb.ProfileStoriesLive do
     else
       [Enum.take(flags, count) | chunk(Enum.drop(flags, count), count, extra)]
     end
+  end
+
+  defp chunk_five_flags_if_stories_are_empty(flags) do
+    flags = Enum.chunk_every(flags, 5)
+
+    stories =
+      Enum.map(1..(5 * length(flags)), fn _ ->
+        %{id: System.unique_integer(), photo: nil, headline: nil, content: nil}
+      end)
+
+    Enum.zip(flags, stories)
   end
 
   defp get_amount_to_chunk(stories, flags) do

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -119,7 +119,7 @@ defmodule AniminaWeb.RootTest do
 
       current_points = User.by_username!(user.username).credit_points
 
-      {:ok, index_live, html} =
+      {:ok, index_live, _html} =
         conn
         |> login_user(%{"username_or_email" => user.username, "password" => @valid_attrs.password})
         |> live(~p"/my/potential-partner/")
@@ -139,7 +139,7 @@ defmodule AniminaWeb.RootTest do
 
       current_points = User.by_username!(user.username).credit_points
 
-      {:ok, index_live, html} =
+      {:ok, index_live, _html} =
         conn
         |> login_user(%{"username_or_email" => user.username, "password" => @valid_attrs.password})
         |> live(~p"/#{user.username}")


### PR DESCRIPTION
In the PR below , I worked on ensuring all flags and stories are displayed well.
Below are the scenarios I looked at
1. When there are stories and no flags

![Screenshot 2024-05-16 at 07 54 31](https://github.com/animina-dating/animina/assets/86654131/1d06b918-15a3-4f3a-a3a2-a0160d886bf4)


2.When there are stories and flags (here , they are distributed equally)
![Screenshot 2024-05-16 at 06 32 21](https://github.com/animina-dating/animina/assets/86654131/f58501c4-1122-48c7-bbd2-2cd9aacbae2a)

![Screenshot 2024-05-16 at 06 05 01](https://github.com/animina-dating/animina/assets/86654131/d080e758-74ac-4c68-b722-854af9f8fb2e)


![Screenshot 2024-05-16 at 06 06 57](https://github.com/animina-dating/animina/assets/86654131/35074cc1-13bf-4e01-a572-6524470b275d)


3. When there are flags and no stories (flags are shown in groups of 5)
![Screenshot 2024-05-16 at 08 06 15](https://github.com/animina-dating/animina/assets/86654131/bb528917-e79c-4157-85d7-e9248326e83f)

