### PR TITLE
Fix/database config, closes #450

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -8,7 +8,8 @@ config :animina, Animina.Repo,
   database: System.get_env("DATABASE_NAME") || "animina_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
-  pool_size: 10
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "20"),
+  queue_target: String.to_integer(System.get_env("QUEUE_TARGET") || "5000")
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -33,8 +33,9 @@ if config_env() == :prod do
   config :animina, Animina.Repo,
     # ssl: true,
     url: database_url,
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
-    socket_options: maybe_ipv6
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "20"),
+    socket_options: maybe_ipv6,
+    queue_target: String.to_integer(System.get_env("QUEUE_TARGET") || "5000")
 
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,7 +11,8 @@ config :animina, Animina.Repo,
   hostname: "localhost",
   database: "animina_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 10
+  pool_size: 20,
+  queue_target: 5000
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.


### PR DESCRIPTION
I've changed the pool_size and queue_target default config

```
pool_size: String.to_integer(System.get_env("POOL_SIZE") || "20"),
queue_target: String.to_integer(System.get_env("QUEUE_TARGET") || "5000")
```

We also need to track down which resources are causing the slow queries and index the fields we are querying by.