### PR TITLE
Feature/subscribe to user id not username , closes #421

### DIFF
--- a/lib/animina/accounts/resources/reaction.ex
+++ b/lib/animina/accounts/resources/reaction.ex
@@ -82,25 +82,15 @@ defmodule Animina.Accounts.Reaction do
 
   changes do
     change after_action(fn changeset, record ->
-             sender_username =
-               User.by_id!(record.sender_id)
-               |> Map.get(:username)
-               |> Ash.CiString.value()
-
-             receiver_username =
-               User.by_id!(record.receiver_id)
-               |> Map.get(:username)
-               |> Ash.CiString.value()
-
              PubSub.broadcast(
                Animina.PubSub,
-               sender_username,
+               record.sender_id,
                {:user, User.by_id!(record.sender_id)}
              )
 
              PubSub.broadcast(
                Animina.PubSub,
-               receiver_username,
+               record.receiver_id,
                {:user, User.by_id!(record.receiver_id)}
              )
 

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -216,9 +216,7 @@ defmodule Animina.Accounts.User do
            on: [:create]
 
     change after_action(fn changeset, record ->
-             username = Ash.CiString.value(record.username)
-
-             PubSub.broadcast(Animina.PubSub, username, {:user, record})
+             PubSub.broadcast(Animina.PubSub, record.id, {:user, record})
 
              {:ok, record}
            end),

--- a/lib/animina/accounts/resources/user_role.ex
+++ b/lib/animina/accounts/resources/user_role.ex
@@ -51,12 +51,11 @@ defmodule Animina.Accounts.UserRole do
 
   changes do
     change after_action(fn changeset, record ->
-             username =
-               User.by_id!(record.user_id)
-               |> Map.get(:username)
-               |> Ash.CiString.value()
-
-             PubSub.broadcast(Animina.PubSub, username, {:user, User.by_id!(record.user_id)})
+             PubSub.broadcast(
+               Animina.PubSub,
+               record.user_id,
+               {:user, User.by_id!(record.user_id)}
+             )
 
              {:ok, record}
            end),

--- a/lib/animina/traits/resources/user_flags.ex
+++ b/lib/animina/traits/resources/user_flags.ex
@@ -1,6 +1,6 @@
 defmodule Animina.Traits.UserFlags do
-  alias Animina.Validations
   alias Animina.Accounts.User
+  alias Animina.Validations
   alias Phoenix.PubSub
 
   @moduledoc """

--- a/lib/animina/traits/resources/user_flags.ex
+++ b/lib/animina/traits/resources/user_flags.ex
@@ -1,5 +1,7 @@
 defmodule Animina.Traits.UserFlags do
   alias Animina.Validations
+  alias Animina.Accounts.User
+  alias Phoenix.PubSub
 
   @moduledoc """
   This is the UserFlags module which we use to manage a user's flags.
@@ -65,6 +67,19 @@ defmodule Animina.Traits.UserFlags do
     define :create
     define :by_id, get_by: [:id], action: :read
     define :destroy
+  end
+
+  changes do
+    change after_action(fn changeset, record ->
+             PubSub.broadcast(
+               Animina.PubSub,
+               record.user_id,
+               {:user, User.by_id!(record.user_id)}
+             )
+
+             {:ok, record}
+           end),
+           on: [:create, :destroy]
   end
 
   preparations do

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -5,7 +5,6 @@ defmodule AniminaWeb.ChatLive do
   alias Animina.Accounts.Message
   alias Animina.Accounts.Points
   alias Animina.Accounts.Reaction
-  alias Animina.Accounts.User
   alias AshPhoenix.Form
   alias Phoenix.PubSub
 
@@ -17,7 +16,7 @@ defmodule AniminaWeb.ChatLive do
 
       PubSub.subscribe(
         Animina.PubSub,
-        "#{socket.assigns.current_user.username}"
+        "#{socket.assigns.current_user.id}"
       )
     end
 
@@ -101,8 +100,6 @@ defmodule AniminaWeb.ChatLive do
       actor: socket.assigns.sender
     )
 
-    broadcast_user(socket)
-
     {:noreply,
      socket
      |> assign(
@@ -117,7 +114,6 @@ defmodule AniminaWeb.ChatLive do
       get_reaction_for_sender_and_receiver(socket.assigns.sender.id, socket.assigns.receiver.id)
 
     Reaction.unlike(reaction, actor: socket.assigns.sender)
-    broadcast_user(socket)
 
     {:noreply,
      socket
@@ -310,16 +306,6 @@ defmodule AniminaWeb.ChatLive do
       forms: [auto?: true]
     )
     |> to_form()
-  end
-
-  defp broadcast_user(socket) do
-    current_user = User.by_id!(socket.assigns.current_user.id)
-
-    PubSub.broadcast(
-      Animina.PubSub,
-      "#{current_user.username}",
-      {:user, current_user}
-    )
   end
 
   @impl true

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -20,7 +20,7 @@ defmodule AniminaWeb.FlagsLive do
 
       PubSub.subscribe(
         Animina.PubSub,
-        "#{socket.assigns.current_user.username}"
+        "#{socket.assigns.current_user.id}"
       )
     end
 
@@ -187,13 +187,9 @@ defmodule AniminaWeb.FlagsLive do
       _ ->
         case socket.assigns.selected do
           0 ->
-            broadcast_user(socket)
-
             {:noreply, successful_socket}
 
           _ ->
-            broadcast_user(socket)
-
             {:noreply, successful_socket}
         end
     end
@@ -296,16 +292,6 @@ defmodule AniminaWeb.FlagsLive do
     |> Enum.filter(fn trait ->
       trait.color == color
     end)
-  end
-
-  defp broadcast_user(socket) do
-    current_user = User.by_id!(socket.assigns.current_user.id)
-
-    PubSub.broadcast(
-      Animina.PubSub,
-      "#{current_user.username}",
-      {:user, current_user}
-    )
   end
 
   @impl true

--- a/lib/animina_web/live/potential_partner_live.ex
+++ b/lib/animina_web/live/potential_partner_live.ex
@@ -131,8 +131,6 @@ defmodule AniminaWeb.PotentialPartnerLive do
           User.by_id!(socket.assigns.current_user.id)
           |> User.update!(form_params)
 
-        broadcast_user(socket)
-
         {:noreply,
          socket
          |> assign(current_user: current_user)
@@ -141,16 +139,6 @@ defmodule AniminaWeb.PotentialPartnerLive do
       _ ->
         {:noreply, assign(socket, update_form: form)}
     end
-  end
-
-  defp broadcast_user(socket) do
-    current_user = User.by_id!(socket.assigns.current_user.id)
-
-    PubSub.broadcast(
-      Animina.PubSub,
-      "#{current_user.username}",
-      {:user, current_user}
-    )
   end
 
   @impl true

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -10,7 +10,6 @@ defmodule AniminaWeb.ProfileLive do
   alias Animina.Accounts.Credit
   alias Animina.Accounts.Points
   alias Animina.Accounts.Reaction
-  alias Animina.Accounts.User
   alias Animina.GenServers.ProfileViewCredits
   alias Phoenix.PubSub
 
@@ -147,7 +146,7 @@ defmodule AniminaWeb.ProfileLive do
 
       PubSub.subscribe(
         Animina.PubSub,
-        "#{socket.assigns.current_user.username}"
+        "#{socket.assigns.current_user.id}"
       )
     end
   end
@@ -229,8 +228,6 @@ defmodule AniminaWeb.ProfileLive do
       actor: socket.assigns.current_user
     )
 
-    broadcast_user(socket)
-
     {:noreply,
      socket
      |> assign(
@@ -245,7 +242,6 @@ defmodule AniminaWeb.ProfileLive do
       get_reaction_for_sender_and_receiver(socket.assigns.current_user.id, socket.assigns.user.id)
 
     Reaction.unlike(reaction, actor: socket.assigns.current_user)
-    broadcast_user(socket)
 
     {:noreply,
      socket
@@ -402,16 +398,6 @@ defmodule AniminaWeb.ProfileLive do
       Reaction.by_sender_and_receiver_id(user_id, current_user_id)
 
     reaction
-  end
-
-  defp broadcast_user(socket) do
-    current_user = User.by_id!(socket.assigns.current_user.id)
-
-    PubSub.broadcast(
-      Animina.PubSub,
-      "#{current_user.username}",
-      {:user, current_user}
-    )
   end
 
   @impl true

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -16,7 +16,7 @@ defmodule AniminaWeb.ProfilePhotoLive do
 
       PubSub.subscribe(
         Animina.PubSub,
-        "#{socket.assigns.current_user.username}"
+        "#{socket.assigns.current_user.id}"
       )
     end
 
@@ -108,8 +108,6 @@ defmodule AniminaWeb.ProfilePhotoLive do
         form = Form.validate(socket.assigns.form, params, errors: true)
 
         with [] <- Form.errors(form), {:ok, _photo} <- Form.submit(form, params: params) do
-          broadcast_user(socket)
-
           {:noreply,
            socket
            |> assign(:errors, [])
@@ -137,16 +135,6 @@ defmodule AniminaWeb.ProfilePhotoLive do
        :form,
        Form.for_create(Photo, :create, api: Accounts, as: "photo")
      )}
-  end
-
-  defp broadcast_user(socket) do
-    current_user = User.by_id!(socket.assigns.current_user.id)
-
-    PubSub.broadcast(
-      Animina.PubSub,
-      "#{current_user.username}",
-      {:user, current_user}
-    )
   end
 
   @impl true

--- a/lib/animina_web/live/profile_stories_live.ex
+++ b/lib/animina_web/live/profile_stories_live.ex
@@ -4,12 +4,10 @@ defmodule AniminaWeb.ProfileStoriesLive do
   """
 
   use AniminaWeb, :live_view
-
   alias Animina.Accounts
   alias Animina.Narratives
   alias Animina.Traits
   alias Phoenix.LiveView.AsyncResult
-  alias Phoenix.PubSub
 
   require Ash.Query
 
@@ -91,8 +89,6 @@ defmodule AniminaWeb.ProfileStoriesLive do
 
     case Narratives.Story.destroy(story) do
       :ok ->
-        broadcast_user(socket)
-
         {:noreply,
          socket
          |> delete_story_by_dom_id(dom_id)}
@@ -103,8 +99,6 @@ defmodule AniminaWeb.ProfileStoriesLive do
           when message == "would leave records behind" ->
             Accounts.Photo.destroy(story.photo)
             Narratives.Story.destroy(story)
-
-            broadcast_user(socket)
 
             {:noreply,
              socket
@@ -291,16 +285,6 @@ defmodule AniminaWeb.ProfileStoriesLive do
         emoji: trait.flag.emoji
       }
     end)
-  end
-
-  defp broadcast_user(socket) do
-    current_user = Accounts.User.by_id!(socket.assigns.current_user.id)
-
-    PubSub.broadcast(
-      Animina.PubSub,
-      "#{current_user.username}",
-      {:user, current_user}
-    )
   end
 
   @impl true

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -16,6 +16,11 @@ defmodule AniminaWeb.StoryLive do
     if connected?(socket) do
       PubSub.subscribe(Animina.PubSub, "credits")
       PubSub.subscribe(Animina.PubSub, "messages")
+
+      PubSub.subscribe(
+        Animina.PubSub,
+        "#{socket.assigns.current_user.id}"
+      )
     end
 
     story = Story.by_id!(story_id)
@@ -43,6 +48,11 @@ defmodule AniminaWeb.StoryLive do
     if connected?(socket) do
       PubSub.subscribe(Animina.PubSub, "credits")
       PubSub.subscribe(Animina.PubSub, "messages")
+
+      PubSub.subscribe(
+        Animina.PubSub,
+        "#{socket.assigns.current_user.id}"
+      )
     end
 
     socket =
@@ -237,8 +247,6 @@ defmodule AniminaWeb.StoryLive do
       )
       |> Accounts.create()
 
-      broadcast_user(socket)
-
       {:noreply,
        socket
        |> assign(:errors, [])
@@ -291,8 +299,6 @@ defmodule AniminaWeb.StoryLive do
         )
         |> Accounts.create()
 
-        broadcast_user(socket)
-
         {:noreply,
          socket
          |> assign(:errors, [])
@@ -302,8 +308,6 @@ defmodule AniminaWeb.StoryLive do
          )
          |> push_navigate(to: ~p"/#{socket.assigns.current_user.username}")}
       else
-        broadcast_user(socket)
-
         {:noreply,
          socket
          |> assign(:errors, [])
@@ -404,16 +408,6 @@ defmodule AniminaWeb.StoryLive do
     else
       true
     end
-  end
-
-  defp broadcast_user(socket) do
-    current_user = User.by_id!(socket.assigns.current_user.id)
-
-    PubSub.broadcast(
-      Animina.PubSub,
-      "#{current_user.username}",
-      {:user, current_user}
-    )
   end
 
   @impl true


### PR DESCRIPTION
- In this PR  , I ensured we subscribe to the user id and not the username and removed the `broadcast_user/1` that was in the live view as we now do that in the resources