### PR TITLE
Feature/fetch stories seperately  , closes #418

### DIFF
--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -234,8 +234,6 @@ defmodule Animina.Accounts.User do
                 :credit_points,
                 :profile_photo,
                 :city,
-                :flags,
-                :traits,
                 :roles
               ]
             )

--- a/lib/animina_web/controllers/error_html/404.html.heex
+++ b/lib/animina_web/controllers/error_html/404.html.heex
@@ -12,35 +12,45 @@
     </script>
   </head>
   <body class="bg-white dark:text-white text-gray-900  dark:bg-gray-900 antialiased">
-    
     <main class="block md:hidden">
-  <.top_navigation
-    active_tab={:none}
-    current_user={@current_user}
-    current_user_credit_points={if @current_user do @current_user.credit_points else 0 end}
-    number_of_unread_messages={0}
-  />
-</main>
+      <.top_navigation
+        active_tab={:none}
+        current_user={@current_user}
+        current_user_credit_points={
+          if @current_user do
+            @current_user.credit_points
+          else
+            0
+          end
+        }
+        number_of_unread_messages={0}
+      />
+    </main>
 
-<div class="w-[100%] pt-2 flex justify-center">
-  <.desktop_sidebar
-    active_tab={:none}
-    current_user={@current_user}
-    current_user_credit_points={if @current_user do @current_user.credit_points else 0 end}
-    number_of_unread_messages={0}
-  />
-  <main class="md:w-[78%] w-[100%] flex flex-col gap-2 flex-grow space-y-5 px-3">
-    <.flash_group flash={@flash} />
-   <div class="w-[90%] flex flex-col md:text-xl gap-1 justify-center items-center m-auto text-center pt-12">
-      <p>This profile either doesn't exist or you don't have enough points to access it.</p>
-     
-      <p>You need 20 points to access a .</p>
+    <div class="w-[100%] pt-2 flex justify-center">
+      <.desktop_sidebar
+        active_tab={:none}
+        current_user={@current_user}
+        current_user_credit_points={
+          if @current_user do
+            @current_user.credit_points
+          else
+            0
+          end
+        }
+        number_of_unread_messages={0}
+      />
+      <main class="md:w-[78%] w-[100%] flex flex-col gap-2 flex-grow space-y-5 px-3">
+        <.flash_group flash={@flash} />
+        <div class="w-[90%] flex flex-col md:text-xl gap-1 justify-center items-center m-auto text-center pt-12">
+          <p>This profile either doesn't exist or you don't have enough points to access it.</p>
+
+          <p>You need 20 points to access a .</p>
+        </div>
+      </main>
+      <div class="justify-end flex-grow hidden md:flex">
+        <p class="bg-[#C1C6D5] dark:bg-[#414753]  w-[1px] " />
+      </div>
     </div>
-  </main>
-  <div class="justify-end flex-grow hidden md:flex">
-    <p class="bg-[#C1C6D5] dark:bg-[#414753]  w-[1px] " />
-  </div>
-</div>
-
   </body>
 </html>

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -5,6 +5,7 @@ defmodule AniminaWeb.ChatLive do
   alias Animina.Accounts.Message
   alias Animina.Accounts.Points
   alias Animina.Accounts.Reaction
+  alias Animina.Traits.UserFlags
   alias AshPhoenix.Form
   alias Phoenix.PubSub
 
@@ -151,19 +152,23 @@ defmodule AniminaWeb.ChatLive do
   end
 
   defp filter_flags(user, color, language) do
-    traits =
-      user.traits
-      |> Enum.filter(fn trait ->
-        trait.color == color and trait.flag != nil
-      end)
+    case UserFlags.by_user_id(user.id) do
+      {:ok, traits} ->
+        traits
+        |> Enum.filter(fn trait ->
+          trait.color == color and trait.flag != nil
+        end)
+        |> Enum.map(fn trait ->
+            %{
+              id: trait.flag.id,
+              name: get_translation(trait.flag.flag_translations, language),
+              emoji: trait.flag.emoji
+            }
+          end)
 
-    Enum.map(traits, fn trait ->
-      %{
-        id: trait.flag.id,
-        name: get_translation(trait.flag.flag_translations, language),
-        emoji: trait.flag.emoji
-      }
-    end)
+      _ ->
+        []
+    end
   end
 
   defp get_reaction_for_sender_and_receiver(user_id, current_user_id) do

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -2,6 +2,7 @@ defmodule AniminaWeb.ChatLive do
   use AniminaWeb, :live_view
 
   alias Animina.Accounts
+  alias Animina.Accounts.BasicUser
   alias Animina.Accounts.Message
   alias Animina.Accounts.Points
   alias Animina.Accounts.Reaction
@@ -11,16 +12,6 @@ defmodule AniminaWeb.ChatLive do
 
   @impl true
   def mount(%{"profile" => profile} = params, %{"language" => language} = _session, socket) do
-    if connected?(socket) do
-      PubSub.subscribe(Animina.PubSub, "credits:" <> socket.assigns.current_user.id)
-      PubSub.subscribe(Animina.PubSub, "messages")
-
-      PubSub.subscribe(
-        Animina.PubSub,
-        "#{socket.assigns.current_user.id}"
-      )
-    end
-
     sender =
       if params["current_user"] do
         Accounts.User.by_username!(params["current_user"])
@@ -29,6 +20,20 @@ defmodule AniminaWeb.ChatLive do
       end
 
     receiver = Accounts.User.by_username!(profile)
+
+    if connected?(socket) do
+      PubSub.subscribe(Animina.PubSub, "credits:" <> socket.assigns.current_user.id)
+      PubSub.subscribe(Animina.PubSub, "messages")
+
+      PubSub.subscribe(
+        Animina.PubSub,
+        "#{socket.assigns.current_user.id}"
+      )
+
+      Phoenix.PubSub.subscribe(Animina.PubSub, "user_flag:created:#{sender.id}")
+
+      Phoenix.PubSub.subscribe(Animina.PubSub, "user_flag:created:#{receiver.id}")
+    end
 
     {:ok, messages_between_sender_and_receiver} =
       Message.messages_for_sender_and_receiver(sender.id, receiver.id, actor: sender)
@@ -159,12 +164,12 @@ defmodule AniminaWeb.ChatLive do
           trait.color == color and trait.flag != nil
         end)
         |> Enum.map(fn trait ->
-            %{
-              id: trait.flag.id,
-              name: get_translation(trait.flag.flag_translations, language),
-              emoji: trait.flag.emoji
-            }
-          end)
+          %{
+            id: trait.flag.id,
+            name: get_translation(trait.flag.flag_translations, language),
+            emoji: trait.flag.emoji
+          }
+        end)
 
       _ ->
         []
@@ -216,24 +221,10 @@ defmodule AniminaWeb.ChatLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    intersecting_green_flags_count =
-      get_intersecting_flags_count(
-        filter_flags(current_user, :green, socket.assigns.language),
-        filter_flags(socket.assigns.receiver, :white, socket.assigns.language)
-      )
-
-    intersecting_red_flags_count =
-      get_intersecting_flags_count(
-        filter_flags(current_user, :red, socket.assigns.language),
-        filter_flags(socket.assigns.receiver, :white, socket.assigns.language)
-      )
-
     if current_user.id == socket.assigns.receiver.id do
       {:noreply,
        socket
        |> assign(sender: current_user)
-       |> assign(intersecting_green_flags_count: intersecting_green_flags_count)
-       |> assign(intersecting_red_flags_count: intersecting_red_flags_count)
        |> assign(
          current_user_has_liked_profile?:
            current_user_has_liked_profile(current_user.id, socket.assigns.receiver.id)
@@ -241,12 +232,57 @@ defmodule AniminaWeb.ChatLive do
     else
       {:noreply,
        socket
-       |> assign(intersecting_green_flags_count: intersecting_green_flags_count)
        |> assign(
          current_user_has_liked_profile?:
            current_user_has_liked_profile(current_user.id, socket.assigns.receiver.id)
-       )
-       |> assign(intersecting_red_flags_count: intersecting_red_flags_count)}
+       )}
+    end
+  end
+
+  def handle_info(
+        %{event: "create", payload: %{data: %UserFlags{} = user_flag}},
+        socket
+      ) do
+    user_flag_user = BasicUser.by_id!(user_flag.user_id)
+
+    if user_flag.user_id == socket.assigns.current_user.id do
+      intersecting_green_flags_count =
+        get_intersecting_flags_count(
+          filter_flags(user_flag_user, :green, socket.assigns.language),
+          filter_flags(socket.assigns.receiver, :white, socket.assigns.language)
+        )
+
+      intersecting_red_flags_count =
+        get_intersecting_flags_count(
+          filter_flags(user_flag_user, :red, socket.assigns.language),
+          filter_flags(socket.assigns.receiver, :white, socket.assigns.language)
+        )
+
+      {:noreply,
+       socket
+       |> assign(
+         intersecting_green_flags_count: intersecting_green_flags_count,
+         intersecting_red_flags_count: intersecting_red_flags_count
+       )}
+    else
+      intersecting_green_flags_count =
+        get_intersecting_flags_count(
+          filter_flags(socket.assigns.sender, :green, socket.assigns.language),
+          filter_flags(user_flag_user, :white, socket.assigns.language)
+        )
+
+      intersecting_red_flags_count =
+        get_intersecting_flags_count(
+          filter_flags(socket.assigns.sender, :red, socket.assigns.language),
+          filter_flags(user_flag_user, :white, socket.assigns.language)
+        )
+
+      {:noreply,
+       socket
+       |> assign(
+         intersecting_green_flags_count: intersecting_green_flags_count,
+         intersecting_red_flags_count: intersecting_red_flags_count
+       )}
     end
   end
 

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -167,7 +167,7 @@ defmodule AniminaWeb.FlagsLive do
         }
       end)
 
-    socket.assigns.current_user.traits
+    UserFlags.by_user_id!(socket.assigns.current_user.id)
     |> Enum.filter(fn x -> x.color == socket.assigns.color end)
     |> Enum.each(fn x -> UserFlags.destroy(x) end)
 
@@ -288,10 +288,17 @@ defmodule AniminaWeb.FlagsLive do
   end
 
   defp filter_flags(current_user, color) do
-    current_user.traits
-    |> Enum.filter(fn trait ->
-      trait.color == color
-    end)
+    case UserFlags.by_user_id(current_user.id) do
+      {:ok, traits} ->
+        traits
+        |> Enum.filter(fn trait ->
+          trait.color == color
+        end)
+
+      _ ->
+        []
+    end
+
   end
 
   @impl true

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -197,7 +197,7 @@ defmodule AniminaWeb.FlagsLive do
 
   @impl true
   def handle_info({:user, current_user}, socket) do
-    flags = current_user.flags |> Enum.map(fn x -> x.id end)
+    flags = filter_flags(current_user, socket.assigns.color)
 
     {:noreply,
      socket
@@ -298,7 +298,6 @@ defmodule AniminaWeb.FlagsLive do
       _ ->
         []
     end
-
   end
 
   @impl true

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -180,10 +180,12 @@ defmodule AniminaWeb.ProfileLive do
     end
   end
 
-  defp subscribe(socket, _current_user, _user) do
+  defp subscribe(socket, current_user, _user) do
     if connected?(socket) do
       PubSub.subscribe(Animina.PubSub, "credits")
       PubSub.subscribe(Animina.PubSub, "messages")
+
+      
 
       PubSub.subscribe(
         Animina.PubSub,
@@ -420,7 +422,7 @@ defmodule AniminaWeb.ProfileLive do
   end
 
   defp get_intersecting_flags_count(first_flag_array, second_flag_array) do
-    
+
     first_flag_array = Enum.map(first_flag_array, fn x -> x.id end)
     second_flag_array = Enum.map(second_flag_array, fn x -> x.id end)
 

--- a/lib/animina_web/live/profile_stories_live.ex
+++ b/lib/animina_web/live/profile_stories_live.ex
@@ -24,6 +24,11 @@ defmodule AniminaWeb.ProfileStoriesLive do
         []
       end
 
+
+      if connected?(socket) do
+        Phoenix.PubSub.subscribe(Animina.PubSub, "story:created:#{user_id}")
+      end
+
     current_user_red_flags =
       if current_user do
         fetch_flags(current_user.id, :red) |> filter_flags(:red, language)
@@ -128,6 +133,20 @@ defmodule AniminaWeb.ProfileStoriesLive do
     {:noreply, update_photo(socket, photo)}
   end
 
+  @impl true
+  def handle_info(
+        %{event: "create", payload: %{data: %Narratives.Story{} = story}},
+        socket
+      ) do
+
+    {:noreply,
+    socket
+    |> stream(
+      :stories_and_flags,
+      fetch_stories_and_flags(story.user_id, socket.assigns.language),
+      reset: true
+    )}
+  end
   @impl true
   def handle_info(
         %{event: "reject", payload: %{data: %Accounts.Photo{} = photo}},

--- a/lib/animina_web/live/profile_stories_live.ex
+++ b/lib/animina_web/live/profile_stories_live.ex
@@ -24,10 +24,10 @@ defmodule AniminaWeb.ProfileStoriesLive do
         []
       end
 
-
-      if connected?(socket) do
-        Phoenix.PubSub.subscribe(Animina.PubSub, "story:created:#{user_id}")
-      end
+    if connected?(socket) do
+      Phoenix.PubSub.subscribe(Animina.PubSub, "story:created:#{user_id}")
+      Phoenix.PubSub.subscribe(Animina.PubSub, "user_flag:created:#{user_id}")
+    end
 
     current_user_red_flags =
       if current_user do
@@ -138,15 +138,28 @@ defmodule AniminaWeb.ProfileStoriesLive do
         %{event: "create", payload: %{data: %Narratives.Story{} = story}},
         socket
       ) do
-
     {:noreply,
-    socket
-    |> stream(
-      :stories_and_flags,
-      fetch_stories_and_flags(story.user_id, socket.assigns.language),
-      reset: true
-    )}
+     socket
+     |> stream(
+       :stories_and_flags,
+       fetch_stories_and_flags(story.user_id, socket.assigns.language),
+       reset: true
+     )}
   end
+
+  def handle_info(
+        %{event: "create", payload: %{data: %Traits.UserFlags{} = user_flag}},
+        socket
+      ) do
+    {:noreply,
+     socket
+     |> stream(
+       :stories_and_flags,
+       fetch_stories_and_flags(user_flag.user_id, socket.assigns.language),
+       reset: true
+     )}
+  end
+
   @impl true
   def handle_info(
         %{event: "reject", payload: %{data: %Accounts.Photo{} = photo}},


### PR DESCRIPTION
- In this PR I removed the story and flags preload from the user resource that slowed down the system
- I fetch flags and stories seperately
- I have handled pubsub updates for the live views from the resource to ensure we have same user content