### PR TITLE
Feature/when to display photos , closes #452

### DIFF
--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -6,6 +6,7 @@ defmodule Animina.Accounts.Photo do
 
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer,
+    authorizers: Ash.Policy.Authorizer,
     notifiers: [Ash.Notifier.PubSub],
     extensions: [AshStateMachine, AshOban]
 
@@ -30,6 +31,18 @@ defmodule Animina.Accounts.Photo do
 
     create_timestamp :created_at
     update_timestamp :updated_at
+  end
+
+  relationships do
+    belongs_to :user, Animina.Accounts.User do
+      allow_nil? false
+      attribute_writable? true
+    end
+
+    belongs_to :story, Animina.Narratives.Story do
+      api Animina.Narratives
+      attribute_writable? true
+    end
   end
 
   pub_sub do
@@ -74,18 +87,6 @@ defmodule Animina.Accounts.Photo do
 
         on_error :error
       end
-    end
-  end
-
-  relationships do
-    belongs_to :user, Animina.Accounts.User do
-      allow_nil? false
-      attribute_writable? true
-    end
-
-    belongs_to :story, Animina.Narratives.Story do
-      api Animina.Narratives
-      attribute_writable? true
     end
   end
 
@@ -160,6 +161,12 @@ defmodule Animina.Accounts.Photo do
                |> Accounts.update()
            end),
            on: :update
+  end
+
+  policies do
+    policy action(:read) do
+      authorize_if Animina.Checks.ReadPhotoCheck
+    end
   end
 
   postgres do

--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -22,7 +22,7 @@ defmodule Animina.Accounts.Photo do
     attribute :error_state, :string
 
     attribute :state, :atom do
-      constraints one_of: [:pending_review, :in_review, :approved, :rejected, :error]
+      constraints one_of: [:pending_review, :in_review, :approved, :rejected, :error, :nsfw]
 
       default :pending_review
       allow_nil? false
@@ -52,6 +52,7 @@ defmodule Animina.Accounts.Photo do
       transition(:approve, from: :in_review, to: :approved)
       transition(:report, from: :approved, to: :in_review)
       transition(:reject, from: :in_review, to: :rejected)
+      transition(:nsfw, from: :in_review, to: :nsfw)
       transition(:error, from: [:pending_review, :in_review, :approved, :rejected], to: :error)
     end
   end
@@ -118,6 +119,10 @@ defmodule Animina.Accounts.Photo do
 
     update :reject do
       change transition_state(:rejected)
+    end
+
+    update :nsfw do
+      change transition_state(:nsfw)
     end
 
     update :error do

--- a/lib/animina/actions/process_photo.ex
+++ b/lib/animina/actions/process_photo.ex
@@ -43,7 +43,7 @@ defmodule Animina.Actions.ProcessPhoto do
         |> Accounts.update(authorize?: false)
       else
         photo
-        |> Ash.Changeset.for_update(:reject, %{})
+        |> Ash.Changeset.for_update(:nsfw, %{})
         |> Accounts.update(authorize?: false)
       end
 

--- a/lib/animina/checks/read_photo_check.ex
+++ b/lib/animina/checks/read_photo_check.ex
@@ -1,0 +1,33 @@
+defmodule Animina.Checks.ReadPhotoCheck do
+  @moduledoc """
+  Policy for The Read Action for a Photo
+  """
+  use Ash.Policy.SimpleCheck
+  alias Animina.Accounts.BasicUser
+
+  def describe(_opts) do
+    "Ensures an actor can only read photos if they are from a public account if the actor is nil"
+  end
+
+  def match?(actor, params, _opts) do
+    if actor do
+      true
+    else
+      if params.query.arguments != %{} and params.query.arguments.user_id != nil do
+        check_if_user_is_public(params.query.arguments.user_id)
+      else
+        false
+      end
+    end
+  end
+
+  defp check_if_user_is_public(user_id) do
+    user = BasicUser.by_id!(user_id)
+
+    if user.public do
+      true
+    else
+      false
+    end
+  end
+end

--- a/lib/animina_web/components/bookmark/bookmarks_components.ex
+++ b/lib/animina_web/components/bookmark/bookmarks_components.ex
@@ -109,7 +109,7 @@ defmodule AniminaWeb.BookmarksComponents do
   end
 
   def display_image(:nsfw, current_user, bookmark) do
-    if bookmark.owner_id == current_user.id || is_admin?(current_user) do
+    if bookmark.owner_id == current_user.id || admin_user?(current_user) do
       true
     else
       false
@@ -120,7 +120,7 @@ defmodule AniminaWeb.BookmarksComponents do
     false
   end
 
-  def is_admin?(current_user) do
+  def admin_user?(current_user) do
     case current_user.roles do
       [] ->
         false

--- a/lib/animina_web/components/bookmark/bookmarks_components.ex
+++ b/lib/animina_web/components/bookmark/bookmarks_components.ex
@@ -18,15 +18,17 @@ defmodule AniminaWeb.BookmarksComponents do
     <div class="pb-2 px-4">
       <.link navigate={"/#{@bookmark.user.username}" }>
         <div class="flex items-start justify-between space-x-4 mt-4">
-          <div>
+          <div :if={@bookmark.user.profile_photo}>
             <img
-              :if={@bookmark.user.profile_photo && @bookmark.user.profile_photo.state == :approved}
+              :if={display_image(@bookmark.user.profile_photo.state, @current_user, @bookmark)}
               class="object-cover rounded-lg aspect-square h-24 w-24"
               src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @bookmark.user.profile_photo.filename}
             />
 
             <div
-              :if={@bookmark.user.profile_photo && @bookmark.user.profile_photo.state != :approved}
+              :if={
+                !display_image(@bookmark.user.profile_photo.state, @current_user, @bookmark) == false
+              }
               class="bg-gray-200 dark:bg-gray-800 h-24 w-24 rounded-lg  flex items-center justify-center"
             >
             </div>
@@ -77,6 +79,42 @@ defmodule AniminaWeb.BookmarksComponents do
       </.link>
     </div>
     """
+  end
+
+  def display_image(:nsfw, current_user, bookmark) do
+    if bookmark.owner_id == current_user.id || is_admin?(current_user) do
+      true
+    else
+      false
+    end
+  end
+
+  def display_image(:pending_review, _, _) do
+    true
+  end
+
+  def display_image(:approved, _, _) do
+    true
+  end
+
+  def display_image(:in_review, _, _) do
+    true
+  end
+
+  def display_image(_, _, _) do
+    false
+  end
+
+  def is_admin?(current_user) do
+    case current_user.roles do
+      [] ->
+        false
+
+      roles ->
+        roles
+        |> Enum.map(fn x -> x.name end)
+        |> Enum.any?(fn x -> x == :admin end)
+    end
   end
 
   attr :bookmark, :any, required: true

--- a/lib/animina_web/components/bookmark/bookmarks_components.ex
+++ b/lib/animina_web/components/bookmark/bookmarks_components.ex
@@ -19,11 +19,20 @@ defmodule AniminaWeb.BookmarksComponents do
       <.link navigate={"/#{@bookmark.user.username}" }>
         <div class="flex items-start justify-between space-x-4 mt-4">
           <div :if={@bookmark.user.profile_photo}>
-            <img
-              :if={display_image(@bookmark.user.profile_photo.state, @current_user, @bookmark)}
-              class="object-cover rounded-lg aspect-square h-24 w-24"
-              src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @bookmark.user.profile_photo.filename}
-            />
+            <div class="relative">
+              <img
+                :if={display_image(@bookmark.user.profile_photo.state, @current_user, @bookmark)}
+                class="object-cover rounded-lg aspect-square h-24 w-24"
+                src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @bookmark.user.profile_photo.filename}
+              />
+
+              <p
+                :if={@bookmark.user.profile_photo.state == :nsfw}
+                class="p-1 text-xs dark:bg-gray-800 bg-gray-200 text-black absolute bottom-2 right-4 rounded-md dark:text-white"
+              >
+                NSFW
+              </p>
+            </div>
 
             <div
               :if={

--- a/lib/animina_web/components/bookmark/bookmarks_components.ex
+++ b/lib/animina_web/components/bookmark/bookmarks_components.ex
@@ -19,9 +19,11 @@ defmodule AniminaWeb.BookmarksComponents do
       <.link navigate={"/#{@bookmark.user.username}" }>
         <div class="flex items-start justify-between space-x-4 mt-4">
           <div :if={@bookmark.user.profile_photo}>
-            <div class="relative">
+            <div
+              :if={display_image(@bookmark.user.profile_photo.state, @current_user, @bookmark)}
+              class="relative"
+            >
               <img
-                :if={display_image(@bookmark.user.profile_photo.state, @current_user, @bookmark)}
                 class="object-cover rounded-lg aspect-square h-24 w-24"
                 src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @bookmark.user.profile_photo.filename}
               />
@@ -90,24 +92,28 @@ defmodule AniminaWeb.BookmarksComponents do
     """
   end
 
+  def display_image(:pending_review, nil, _) do
+    true
+  end
+
+  def display_image(:approved, nil, _) do
+    true
+  end
+
+  def display_image(:in_review, nil, _) do
+    true
+  end
+
+  def display_image(_, nil, _) do
+    false
+  end
+
   def display_image(:nsfw, current_user, bookmark) do
     if bookmark.owner_id == current_user.id || is_admin?(current_user) do
       true
     else
       false
     end
-  end
-
-  def display_image(:pending_review, _, _) do
-    true
-  end
-
-  def display_image(:approved, _, _) do
-    true
-  end
-
-  def display_image(:in_review, _, _) do
-    true
   end
 
   def display_image(_, _, _) do

--- a/lib/animina_web/components/chat/chat_components.ex
+++ b/lib/animina_web/components/chat/chat_components.ex
@@ -105,7 +105,7 @@ defmodule AniminaWeb.ChatComponents do
             </div>
           </div>
         </div>
-        <.user_image user={@sender} />
+        <.sender_user_image user={@sender} />
       </div>
     <% end %>
     """
@@ -115,7 +115,7 @@ defmodule AniminaWeb.ChatComponents do
     ~H"""
     <%= if @sender.id != @message.sender_id do %>
       <div class="flex justify-start gap-4  item-start text-black">
-        <.user_image user={@receiver} />
+        <.receiver_user_image user={@receiver} current_user={@sender} />
         <div class="justify-start flex items-start flex-col">
           <p class="dark:text-white">
             <%= @receiver.username %>
@@ -135,20 +135,7 @@ defmodule AniminaWeb.ChatComponents do
     """
   end
 
-  def receiver_profile_box(assigns) do
-    ~H"""
-    <div class="bg-indigo-500 p-4 text-white h-[100%] flex gap-4 items-center">
-      <div class="flex items-center gap-2">
-        <.user_image user={@receiver} />
-        <p>
-          <%= @receiver.username %>
-        </p>
-      </div>
-    </div>
-    """
-  end
-
-  def user_image(assigns) do
+  def sender_user_image(assigns) do
     ~H"""
     <%= if @user && @user.profile_photo  do %>
       <img class="object-cover w-8 h-8 rounded-full" src={"/uploads/#{@user.profile_photo.filename}"} />
@@ -169,6 +156,77 @@ defmodule AniminaWeb.ChatComponents do
       </svg>
     <% end %>
     """
+  end
+
+  def receiver_user_image(assigns) do
+    ~H"""
+    <%= if @user && @user.profile_photo && display_image(@user.profile_photo.state, @current_user, @user) do %>
+      <div class="relative">
+        <img
+          class="object-cover w-8 h-8 rounded-full"
+          src={"/uploads/#{@user.profile_photo.filename}"}
+        />
+
+        <p
+          :if={@user.profile_photo.state == :nsfw}
+          class="p-1 text-xs dark:bg-gray-800 bg-gray-200 text-black absolute bottom-2 right-4 rounded-md dark:text-white"
+        >
+          nsfw
+        </p>
+      </div>
+    <% else %>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="w-6 h-6 dark:text-white text-black"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
+        />
+      </svg>
+    <% end %>
+    """
+  end
+
+  def display_image(:nsfw, current_user, receiver) do
+    if current_user.id == receiver.id || is_admin?(current_user) do
+      true
+    else
+      false
+    end
+  end
+
+  def display_image(:pending_review, _, _) do
+    true
+  end
+
+  def display_image(:approved, _, _) do
+    true
+  end
+
+  def display_image(:in_review, _, _) do
+    true
+  end
+
+  def display_image(_, _, _) do
+    false
+  end
+
+  def is_admin?(current_user) do
+    case current_user.roles do
+      [] ->
+        false
+
+      roles ->
+        roles
+        |> Enum.map(fn x -> x.name end)
+        |> Enum.any?(fn x -> x == :admin end)
+    end
   end
 
   def already_read_ticks(assigns) do

--- a/lib/animina_web/components/chat/chat_components.ex
+++ b/lib/animina_web/components/chat/chat_components.ex
@@ -194,7 +194,7 @@ defmodule AniminaWeb.ChatComponents do
   end
 
   def display_image(:nsfw, current_user, receiver) do
-    if current_user.id == receiver.id || is_admin?(current_user) do
+    if current_user.id == receiver.id || admin_user?(current_user) do
       true
     else
       false
@@ -217,7 +217,7 @@ defmodule AniminaWeb.ChatComponents do
     false
   end
 
-  def is_admin?(current_user) do
+  def admin_user?(current_user) do
     case current_user.roles do
       [] ->
         false

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -48,76 +48,27 @@ defmodule AniminaWeb.StoriesComponents do
     <div class="pb-2">
       <div :if={@story.photo} class="pb-2">
         <%= if @story.headline.subject == "About me" do %>
-          <img
-            :if={
-              (@current_user && @story.user_id == @current_user.id) ||
-                @story.photo.state == :approved
-            }
-            class="object-cover rounded-lg aspect-square"
-            src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @story.photo.filename}
-          />
-
-          <div
-            :if={
-              @current_user && @story.user_id != @current_user.id &&
-                @story.photo.state != :approved
-            }
-            class="bg-gray-200 dark:bg-gray-800 h-[300px] rounded-lg w-full flex items-center justify-center"
-          >
-            <div class="flex space-x-2 items-center text-gray-600 dark:text-gray-300">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="w-6 h-6"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
-                />
-              </svg>
-
-              <p>Photo not available</p>
-            </div>
+          <div class="relative">
+            <img
+              :if={display_image(@story.photo.state, @current_user, @story)}
+              class="object-cover rounded-lg aspect-square"
+              src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @story.photo.filename}
+            />
           </div>
         <% else %>
-          <img
-            :if={
-              (@current_user && @story.user_id == @current_user.id) ||
-                @story.photo.state == :approved
-            }
-            class="object-cover rounded-lg"
-            src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @story.photo.filename}
-          />
+          <div class="relative">
+            <img
+              :if={display_image(@story.photo.state, @current_user, @story)}
+              class="object-cover rounded-lg"
+              src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @story.photo.filename}
+            />
 
-          <div
-            :if={
-              @current_user && @story.user_id != @current_user.id &&
-                @story.photo.state != :approved
-            }
-            class="bg-gray-200 dark:bg-gray-800 h-[300px] rounded-lg w-full flex items-center justify-center"
-          >
-            <div class="flex space-x-2 items-center text-gray-600 dark:text-gray-300">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke-width="1.5"
-                stroke="currentColor"
-                class="w-6 h-6"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z"
-                />
-              </svg>
-
-              <p>Photo not available</p>
-            </div>
+            <p
+              :if={@story.photo.state == :nsfw}
+              class="p-1 text-sm dark:bg-gray-800 bg-gray-200 text-black absolute bottom-2 right-4 rounded-md dark:text-white"
+            >
+              NSFW
+            </p>
           </div>
         <% end %>
 
@@ -158,6 +109,42 @@ defmodule AniminaWeb.StoriesComponents do
 
   def empty_flags_array?(array) when is_list(array) do
     Enum.all?(array, fn x -> is_map(x) && Map.values(x) == [] end)
+  end
+
+  def display_image(:nsfw, current_user, story) do
+    if story.user_id == current_user.id || is_admin?(current_user) do
+      true
+    else
+      false
+    end
+  end
+
+  def display_image(:pending_review, _, _) do
+    true
+  end
+
+  def display_image(:approved, _, _) do
+    true
+  end
+
+  def display_image(:in_review, _, _) do
+    true
+  end
+
+  def display_image(_, _, _) do
+    false
+  end
+
+  def is_admin?(current_user) do
+    case current_user.roles do
+      [] ->
+        false
+
+      roles ->
+        roles
+        |> Enum.map(fn x -> x.name end)
+        |> Enum.any?(fn x -> x == :admin end)
+    end
   end
 
   attr :story, :any, required: true

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -48,9 +48,14 @@ defmodule AniminaWeb.StoriesComponents do
     <div class="pb-2">
       <div :if={@story.photo} class="pb-2">
         <%= if @story.headline.subject == "About me" do %>
-          <div class="relative">
+          <div
+            :if={
+              (@current_user && @story.user_id == @current_user.id) ||
+                display_image(@story.photo.state, @current_user, @story)
+            }
+            class="relative"
+          >
             <img
-              :if={display_image(@story.photo.state, @current_user, @story)}
               class="object-cover rounded-lg aspect-square"
               src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @story.photo.filename}
             />
@@ -62,9 +67,14 @@ defmodule AniminaWeb.StoriesComponents do
             </p>
           </div>
         <% else %>
-          <div class="relative">
+          <div
+            :if={
+              (@current_user && @story.user_id == @current_user.id) ||
+                display_image(@story.photo.state, @current_user, @story)
+            }
+            class="relative"
+          >
             <img
-              :if={display_image(@story.photo.state, @current_user, @story)}
               class="object-cover rounded-lg"
               src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @story.photo.filename}
             />
@@ -113,24 +123,28 @@ defmodule AniminaWeb.StoriesComponents do
     Enum.all?(array, fn x -> is_map(x) && Map.values(x) == [] end)
   end
 
+  def display_image(:pending_review, nil, _) do
+    true
+  end
+
+  def display_image(:approved, nil, _) do
+    true
+  end
+
+  def display_image(:in_review, nil, _) do
+    true
+  end
+
+  def display_image(_, nil, _) do
+    false
+  end
+
   def display_image(:nsfw, current_user, story) do
     if story.user_id == current_user.id || is_admin?(current_user) do
       true
     else
       false
     end
-  end
-
-  def display_image(:pending_review, _, _) do
-    true
-  end
-
-  def display_image(:approved, _, _) do
-    true
-  end
-
-  def display_image(:in_review, _, _) do
-    true
   end
 
   def display_image(_, _, _) do

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -54,6 +54,12 @@ defmodule AniminaWeb.StoriesComponents do
               class="object-cover rounded-lg aspect-square"
               src={AniminaWeb.Endpoint.url() <> "/uploads/" <> @story.photo.filename}
             />
+            <p
+              :if={@story.photo.state == :nsfw}
+              class="p-1 text-xs dark:bg-gray-800 bg-gray-200 text-black absolute bottom-2 right-4 rounded-md dark:text-white"
+            >
+              NSFW
+            </p>
           </div>
         <% else %>
           <div class="relative">
@@ -65,16 +71,12 @@ defmodule AniminaWeb.StoriesComponents do
 
             <p
               :if={@story.photo.state == :nsfw}
-              class="p-1 text-sm dark:bg-gray-800 bg-gray-200 text-black absolute bottom-2 right-4 rounded-md dark:text-white"
+              class="p-1 text-xs dark:bg-gray-800 bg-gray-200 text-black absolute bottom-2 right-4 rounded-md dark:text-white"
             >
               NSFW
             </p>
           </div>
         <% end %>
-
-        <%!-- <div class="flex w-full justify-end">
-          <p class="text-red-500"><%= @story.photo.state %></p>
-        </div> --%>
       </div>
 
       <.story_body

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -140,7 +140,7 @@ defmodule AniminaWeb.StoriesComponents do
   end
 
   def display_image(:nsfw, current_user, story) do
-    if story.user_id == current_user.id || is_admin?(current_user) do
+    if story.user_id == current_user.id || admin_user?(current_user) do
       true
     else
       false
@@ -151,7 +151,7 @@ defmodule AniminaWeb.StoriesComponents do
     false
   end
 
-  def is_admin?(current_user) do
+  def admin_user?(current_user) do
     case current_user.roles do
       [] ->
         false

--- a/lib/animina_web/live/bookmarks_list_live.ex
+++ b/lib/animina_web/live/bookmarks_list_live.ex
@@ -150,7 +150,7 @@ defmodule AniminaWeb.BookmarksListLive do
   defp fetch_bookmarks(current_user, reason) do
     Accounts.Bookmark
     |> Ash.Query.for_read(:by_reason, %{owner_id: current_user.id, reason: reason})
-    |> Accounts.read!(actor: current_user, page: [limit: 50])
+    |> Accounts.read!(page: [limit: 50])
     |> then(& &1.results)
   end
 


### PR DESCRIPTION
- [x] created a new `:nsfw` state which gets set by the AI when it thinks that the photo is not suitable for work.
- [x] display `:nsfw` images only for their owner and admins 
- [x] display all images to their owner and admins
- [x] display a NSFW label over or near the that `:nsfw` image
- [x] For anybody else: Only display images with `[:pending_review, :in_review, :approved]` state
- [x] Complete this for chat , profile and bookmark lives
![Screenshot 2024-05-25 at 09 34 48](https://github.com/animina-dating/animina/assets/86654131/7006be0e-a430-4eba-87fe-a1e690d9c84e)

![Screenshot 2024-05-25 at 09 32 32](https://github.com/animina-dating/animina/assets/86654131/a0e6897a-c80b-488a-be24-1b2044d48d42)
