### PR TITLE
Downgrade Erlang to 26.2.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.0
+erlang 26.2.5
 elixir 1.16.3


### PR DESCRIPTION
Because of https://hexdocs.pm/elixir/compatibility-and-deprecations.html