### PR TITLE
Disable ML features during CI testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
           PGPASSWORD: postgres
           PGDATABASE: animina_test
           CI: true  # Set a CI environment variable
+          DISABLE_ML_FEATURES: true  # Disable ML features
         run: mix test
 
       - name: Run Credo


### PR DESCRIPTION
Should speed up the test quite a bit. Maybe we have to undo this in the future.