### PR TITLE
Feature/redirect my/profile , closes #533

### DIFF
--- a/lib/animina_web/components/top_navigation_components.ex
+++ b/lib/animina_web/components/top_navigation_components.ex
@@ -322,7 +322,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
     </div>
 
     <div :if={@current_user != nil}>
-     <.link navigate={"/my/profile"} class="flex gap-2 md:flex-row flex-col items-center" >
+     <.link navigate={"/#{@current_user.username}"} class="flex gap-2 md:flex-row flex-col items-center" >
      <svg
           xmlns="http://www.w3.org/2000/svg"
           class="w-6 h-6 stroke-current shrink-0"

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -172,7 +172,8 @@ defmodule AniminaWeb.ProfileLive do
            |> assign(
              current_user_has_liked_profile?:
                current_user_has_liked_profile(socket.assigns.current_user, user.id)
-           )}
+           )
+           |> redirect_to_username(username)}
         end
 
       _ ->
@@ -244,6 +245,11 @@ defmodule AniminaWeb.ProfileLive do
     else
       socket
     end
+  end
+
+  defp redirect_to_username(socket, username) do
+    socket
+    |> push_redirect(to: ~p"/#{username}")
   end
 
   defp subscribe(socket, current_user, user) do

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -164,11 +164,12 @@ defmodule AniminaWeb.ProfileTest do
       assert visit_log_entry.user_id == public_user.id
     end
 
-    test "If you are logged in and you visit /my/profile you see your profile", %{
-      conn: conn,
-      public_user: public_user
-    } do
-      {:ok, _index_live, html} =
+    test "If you are logged in and you visit /my/profile you are redirected to  your profile with your username",
+         %{
+           conn: conn,
+           public_user: public_user
+         } do
+      {_, {:live_redirect, %{to: username}}} =
         conn
         |> login_user(%{
           "username_or_email" => public_user.username,
@@ -176,7 +177,7 @@ defmodule AniminaWeb.ProfileTest do
         })
         |> live(~p"/my/profile")
 
-      assert html =~ public_user.name
+      assert username == "/#{public_user.username}"
     end
 
     test "Anonymous Users Get a 404 Error Page when they visit `my/profile`", %{


### PR DESCRIPTION
I worked on the following

- [ ] Changed all internal links to /my/profile and change them so /:username where :username is the account of the current_user
- [ ]  Add a redirect from /my/profile to /:username so that we can still use the /my/profile URL in documentation, knowing that the system will redirect the current_user to his/her actual /:username profile.
- [ ]  Add a test for the redirect.



https://github.com/animina-dating/animina/assets/86654131/6cc21ded-65bb-4c48-8543-f506e39fb6df


