### PR TITLE
 Make new posts only available when there are at least 3 stories  , closes #575

### DIFF
--- a/lib/animina/checks/create_post_check.ex
+++ b/lib/animina/checks/create_post_check.ex
@@ -1,0 +1,29 @@
+defmodule Animina.Checks.CreatePostCheck do
+  @moduledoc """
+  Policy for The Post Resource
+  """
+  alias Animina.Narratives
+  use Ash.Policy.SimpleCheck
+
+  def describe(_opts) do
+    "Check a user cannot add a post if do not have at least 3 stories"
+  end
+
+  def match?(actor, %{changeset: %Ash.Changeset{} = _changeset}, _opts) do
+    if Enum.count(fetch_stories(actor.id)) >= 3 do
+      true
+    else
+      false
+    end
+  end
+
+  defp fetch_stories(user_id) do
+    stories =
+      Narratives.Story
+      |> Ash.Query.for_read(:by_user_id, %{user_id: user_id})
+      |> Narratives.read!(page: [limit: 50])
+      |> then(& &1.results)
+
+    stories
+  end
+end

--- a/lib/animina/narratives/resources/post.ex
+++ b/lib/animina/narratives/resources/post.ex
@@ -147,7 +147,7 @@ defmodule Animina.Narratives.Post do
     end
 
     policy action_type(:create) do
-      authorize_if actor_present()
+      authorize_if Animina.Checks.CreatePostCheck
     end
 
     policy action_type(:update) do


### PR DESCRIPTION
- [x] Ensured users only see the "Add Post" button if they have at least 3 stories and on the resource side , I added a check for ensuring this is looked at when adding Posts
- [x]  I modified the tests to consider the changes added
![Screenshot 2024-06-04 at 12 11 54](https://github.com/animina-dating/animina/assets/86654131/28e55a5b-a831-452d-85eb-77980db55e24)
![Screenshot 2024-06-04 at 12 12 21](https://github.com/animina-dating/animina/assets/86654131/04d6e4a8-65a9-4ad7-a2c1-f25a01bf9f60)
