### PR TITLE
Feature/display potential partners on dashboard ,  closes #538

### DIFF
--- a/lib/animina/accounts/resources/bookmark.ex
+++ b/lib/animina/accounts/resources/bookmark.ex
@@ -132,6 +132,16 @@ defmodule Animina.Accounts.Bookmark do
 
     destroy :unlike do
     end
+
+    read :by_owner do
+      argument :owner_id, :uuid do
+        allow_nil? false
+      end
+
+      prepare build(load: [:user])
+
+      filter expr(owner_id == ^arg(:owner_id))
+    end
   end
 
   code_interface do
@@ -144,6 +154,7 @@ defmodule Animina.Accounts.Bookmark do
     define :destroy
     define :by_id, get_by: [:id], action: :read
     define :by_owner_user_and_reason, get_by: [:owner_id, :user_id, :reason], action: :read
+    define :by_owner, args: [:owner_id]
     define :most_often_visited_by_user, args: [:owner_id]
     define :longest_overall_duration_visited_by_user, args: [:owner_id]
   end

--- a/lib/animina/narratives/resources/story.ex
+++ b/lib/animina/narratives/resources/story.ex
@@ -87,6 +87,14 @@ defmodule Animina.Narratives.Story do
 
       filter expr(is_nil(headline_id) == ^false and user_id == ^arg(:user_id))
     end
+
+    read :about_story_by_user do
+      argument :user_id, :uuid, allow_nil?: false
+
+      prepare build(load: [:headline])
+
+      filter expr(user_id == ^arg(:user_id) and headline.subject == "About me")
+    end
   end
 
   code_interface do
@@ -97,6 +105,7 @@ defmodule Animina.Narratives.Story do
     define :destroy
     define :by_id, get_by: [:id], action: :read
     define :by_user_id, args: [:user_id]
+    define :about_story_by_user, args: [:user_id], get?: true
   end
 
   identities do

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -5,9 +5,12 @@ defmodule AniminaWeb.DashboardLive do
   alias Animina.Accounts.Message
   alias Animina.Accounts.Reaction
   alias Animina.Accounts.User
+  alias Animina.Narratives.Story
   alias Animina.GenServers.ProfileViewCredits
   alias AshPhoenix.Form
+  alias Animina.Markdown
   alias Phoenix.PubSub
+  alias AniminaWeb.PotentialPartner
 
   require Ash.Query
   require Ash.Sort
@@ -75,6 +78,16 @@ defmodule AniminaWeb.DashboardLive do
       |> assign(total_likes_received_by_user: total_likes_received_by_user)
 
     {:ok, socket}
+  end
+
+  defp get_about_me_story_by_user(user_id) do
+    case Story.about_story_by_user(user_id) do
+      {:ok, story} ->
+        story
+
+      _ ->
+        nil
+    end
   end
 
   defp create_message_form do
@@ -239,6 +252,7 @@ defmodule AniminaWeb.DashboardLive do
           |> raw() %>
         </p>
       </div>
+
       <ul
         role="list"
         class="grid max-w-2xl grid-cols-1 mx-auto mt-10 gap-x-8 gap-y-16 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-4"
@@ -249,25 +263,50 @@ defmodule AniminaWeb.DashboardLive do
               navigate={~p"/#{potential_partner.username}"}
               class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
             >
-              <img
-                class="aspect-[1/1] w-full rounded-2xl object-cover"
-                src={"/uploads/#{potential_partner.profile_photo.filename}"}
-                alt={
-                  gettext("Image of %{name}.",
-                    name: potential_partner.name |> Phoenix.HTML.Safe.to_iodata() |> to_string()
-                  )
-                  |> raw()
-                }
-              />
+              <div class="relative">
+                <img
+                  :if={
+                    potential_partner && potential_partner.profile_photo &&
+                      display_potential_partner(
+                        potential_partner.profile_photo.state,
+                        @current_user,
+                        potential_partner
+                      )
+                  }
+                  class="aspect-[1/1] w-full rounded-2xl object-cover"
+                  src={"/uploads/#{potential_partner.profile_photo.filename}"}
+                  alt={
+                    gettext("Image of %{name}.",
+                      name: potential_partner.name |> Phoenix.HTML.Safe.to_iodata() |> to_string()
+                    )
+                    |> raw()
+                  }
+                />
+                <p
+                  :if={
+                    @current_user && potential_partner.profile_photo.state != :approved &&
+                      current_user_admin?(@current_user)
+                  }
+                  class={"p-1 text-[10px] #{get_photo_state_styling(potential_partner.profile_photo.state)} absolute top-2 left-2 rounded-md "}
+                >
+                  <%= get_photo_state_name(potential_partner.profile_photo.state) %>
+                </p>
+              </div>
 
-              <h3 class="mt-6 text-lg font-semibold leading-8 tracking-tight text-gray-900">
+              <h3 class="mt-6 text-lg font-semibold leading-8 tracking-tight text-gray-900 dark:text-gray-300">
                 <%= potential_partner.name %>
               </h3>
             </.link>
 
-            <p class="text-base leading-7 text-gray-600">
-              Lorepsum Ipsum. This should be the first 200 characters of the "about me" story. ...
-            </p>
+            <div
+              :if={get_about_me_story_by_user(potential_partner.id).content != nil}
+              class="text-base leading-7 text-gray-600 dark:text-gray-400"
+            >
+              <%= Markdown.format(
+                get_about_me_story_by_user(potential_partner.id).content
+                |> String.slice(0, 200)
+              ) %>';lknkm'
+            </div>
             <div class="pt-2">
               <span class="inline-flex items-center px-2 py-1 text-xs font-medium text-blue-700 bg-blue-100 rounded-md">
                 <%= potential_partner.age %> <%= gettext("years") |> raw() %>
@@ -328,6 +367,102 @@ defmodule AniminaWeb.DashboardLive do
         |> Ash.Query.sort(Ash.Sort.expr_sort(fragment("RANDOM()")))
         |> Ash.Query.limit(4)
         |> Accounts.read!()
+    end
+  end
+
+  defp get_photo_state_styling(:error) do
+    "bg-red-500 text-white"
+  end
+
+  defp get_photo_state_styling(:nsfw) do
+    "bg-red-500 text-white"
+  end
+
+  defp get_photo_state_styling(:rejected) do
+    "bg-red-500 text-white"
+  end
+
+  defp get_photo_state_styling(:pending_review) do
+    "bg-yellow-500 text-white"
+  end
+
+  defp get_photo_state_styling(:in_review) do
+    "bg-blue-500 text-white"
+  end
+
+  defp get_photo_state_name(:error) do
+    gettext("Error")
+  end
+
+  defp get_photo_state_name(:nsfw) do
+    gettext("NSFW")
+  end
+
+  defp get_photo_state_name(:rejected) do
+    gettext("Rejected")
+  end
+
+  defp get_photo_state_name(:pending_review) do
+    gettext("Pending review")
+  end
+
+  defp get_photo_state_name(:in_review) do
+    gettext("In review")
+  end
+
+  defp get_photo_state_name(_) do
+    gettext("Error")
+  end
+
+  def display_potential_partner(:pending_review, _, _) do
+    true
+  end
+
+  def display_potential_partner(:approved, _, _) do
+    true
+  end
+
+  def display_potential_partner(:in_review, _, _) do
+    true
+  end
+
+  def display_potential_partner(:error, nil, _) do
+    false
+  end
+
+  def display_potential_partner(:nsfw, nil, _) do
+    false
+  end
+
+  def display_potential_partner(:nsfw, current_user, user) do
+    if user.id == current_user.id || current_user_admin?(current_user) do
+      true
+    else
+      false
+    end
+  end
+
+  def display_potential_partner(:error, current_user, user) do
+    if user.id == current_user.id || current_user_admin?(current_user) do
+      true
+    else
+      false
+    end
+  end
+
+  def display_potential_partner(_, _, _) do
+    false
+  end
+
+  def current_user_admin?(current_user) do
+    case current_user.roles do
+      [] ->
+        false
+
+      roles ->
+        roles
+        |> Enum.map(fn x -> x.name end)
+        |> Enum.any?(fn x -> x == :admin end)
     end
   end
 end

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -5,12 +5,12 @@ defmodule AniminaWeb.DashboardLive do
   alias Animina.Accounts.Message
   alias Animina.Accounts.Reaction
   alias Animina.Accounts.User
-  alias Animina.Narratives.Story
   alias Animina.GenServers.ProfileViewCredits
-  alias AshPhoenix.Form
   alias Animina.Markdown
-  alias Phoenix.PubSub
+  alias Animina.Narratives.Story
   alias AniminaWeb.PotentialPartner
+  alias AshPhoenix.Form
+  alias Phoenix.PubSub
 
   require Ash.Query
   require Ash.Sort
@@ -243,6 +243,7 @@ defmodule AniminaWeb.DashboardLive do
   def render(assigns) do
     ~H"""
     <div class="px-6 mx-auto max-w-7xl lg:px-8">
+    <div :if={PotentialPartner.potential_partners(@current_user, [limit: 4, remove_bookmarked_potential_users: true]) != []}>
       <div class="max-w-2xl mx-auto lg:mx-0">
         <h2 class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">
           <%= gettext("Members you might be interested in") |> raw() %>
@@ -257,7 +258,7 @@ defmodule AniminaWeb.DashboardLive do
         role="list"
         class="grid max-w-2xl grid-cols-1 mx-auto mt-10 gap-x-8 gap-y-16 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-4"
       >
-        <%= for potential_partner <- potential_partners(@current_user) do %>
+        <%= for potential_partner <- PotentialPartner.potential_partners(@current_user, [limit: 4, remove_bookmarked_potential_users: true]) do %>
           <li>
             <.link
               navigate={~p"/#{potential_partner.username}"}
@@ -321,6 +322,8 @@ defmodule AniminaWeb.DashboardLive do
           </li>
         <% end %>
       </ul>
+
+      </div>
 
       <div class="grid grid-cols-1 gap-6 mt-10 md:grid-cols-2">
         <.dashboard_card_like_component

--- a/lib/animina_web/potential_partner.ex
+++ b/lib/animina_web/potential_partner.ex
@@ -24,10 +24,15 @@ defmodule AniminaWeb.PotentialPartner do
     * `"strict_red_flags"` -
       Whether to filter the potential partners by eliminating those that have red flags defined by the user. Defaults to `false`
 
+
+      * `remove_bookmarked_potential_users` -
+      Whether to remove the potential partners that have been bookmarked by the user. Defaults to `false`
+
   """
   def potential_partners(user, options \\ []) do
     limit = Keyword.get(options, :limit, 10)
     strict_red_flags = Keyword.get(options, :strict_red_flags, false)
+    remove_bookmarked = Keyword.get(options, :remove_bookmarked_potential_users, false)
 
     User
     |> Ash.Query.for_read(:read)
@@ -38,8 +43,27 @@ defmodule AniminaWeb.PotentialPartner do
     |> partner_geo_query(user)
     |> partner_green_flags_query(user)
     |> partner_red_flags_query(user, strict_red_flags)
+    |> partner_not_self_query(user)
+    |> partner_bookmarked_query(user, remove_bookmarked)
     |> Ash.Query.limit(limit)
     |> Accounts.read!()
+  end
+
+  defp partner_not_self_query(query, user) do
+    query
+    |> Ash.Query.filter(id: [not_eq: user.id])
+  end
+
+  defp partner_bookmarked_query(query, _user, false) do
+    query
+  end
+
+  defp partner_bookmarked_query(query, user, true) do
+    bookmarked_users =
+      get_bookmarked_users(user.id)
+
+    query
+    |> Ash.Query.filter(id not in ^bookmarked_users)
   end
 
   defp partner_height_query(query, user) do
@@ -55,10 +79,32 @@ defmodule AniminaWeb.PotentialPartner do
   # We use a fragment query to calculate the age of the user as
   # ash does not support using module calculations defined with calculate/3 in filter queries
   defp partner_age_query(query, user) do
+    conditional_partner_age_query(query, user.minimum_partner_age, user.maximum_partner_age)
+  end
+
+  defp conditional_partner_age_query(query, nil, nil) do
+    query
+  end
+
+  defp conditional_partner_age_query(query, minimum_partner_age, nil) do
     query
     |> Ash.Query.filter(
-      fragment("date_part('year', age(current_date, ?))", birthday) <= ^user.maximum_partner_age and
-        fragment("date_part('year', age(current_date, ?))", birthday) >= ^user.minimum_partner_age
+      fragment("date_part('year', age(current_date, ?))", birthday) >= ^minimum_partner_age
+    )
+  end
+
+  defp conditional_partner_age_query(query, nil, maximum_partner_age) do
+    query
+    |> Ash.Query.filter(
+      fragment("date_part('year', age(current_date, ?))", birthday) <= ^maximum_partner_age
+    )
+  end
+
+  defp conditional_partner_age_query(query, minimum_partner_age, maximum_partner_age) do
+    query
+    |> Ash.Query.filter(
+      fragment("date_part('year', age(current_date, ?))", birthday) <= ^maximum_partner_age and
+        fragment("date_part('year', age(current_date, ?))", birthday) >= ^minimum_partner_age
     )
   end
 
@@ -82,7 +128,7 @@ defmodule AniminaWeb.PotentialPartner do
       |> Enum.map(fn flag -> flag.flag_id end)
 
     query
-    |> Ash.Query.filter(flags.color == :green and flags.flag_id in ^white_flags)
+    |> Ash.Query.filter(traits.color == :green and traits.flag_id in ^white_flags)
   end
 
   defp partner_red_flags_query(query, user, strict_red_flags) when strict_red_flags == true do
@@ -91,7 +137,7 @@ defmodule AniminaWeb.PotentialPartner do
       |> Enum.map(fn flag -> flag.flag_id end)
 
     query
-    |> Ash.Query.filter(flags.color == :white and flags.flag_id not in ^red_flags)
+    |> Ash.Query.filter(traits.color == :white and traits.flag_id not in ^red_flags)
   end
 
   defp partner_red_flags_query(query, _user, _strict_red_flags) do
@@ -120,5 +166,15 @@ defmodule AniminaWeb.PotentialPartner do
     UserFlags
     |> Ash.Query.for_read(:by_user_id, %{id: user_id, color: color})
     |> Traits.read!()
+  end
+
+  defp get_bookmarked_users(user_id) do
+    case Accounts.Bookmark.by_owner(user_id) do
+      {:ok, bookmarks} ->
+        Enum.map(bookmarks, fn bookmark -> bookmark.user_id end)
+
+      _ ->
+        []
+    end
   end
 end


### PR DESCRIPTION
- Hello , some important things this PR does  that we need to note.

- [x] Display the Potential User's About me story as markdown
- [x] Ensure the current user can see the profile image of the potential user
- [x] Used the real potential_partners function
- [x] Edited the potential_partners fucntion to take a variable `remove_bookmarked_potential_users` that can be true or false
- [x] Ensured this query does not return the current_user
- [x] If Potential partners are empty for a user, we do not show that section completely , I think It would be discouraging telling a user ` You do not have Potential Partners` in the spirit of not leaving empty spaces.

![Screenshot 2024-06-05 at 19 08 35](https://github.com/animina-dating/animina/assets/86654131/6e636475-9d8a-4e30-96a6-adac6850fe52)
![Screenshot 2024-06-06 at 06 13 21](https://github.com/animina-dating/animina/assets/86654131/9379a054-aeb9-4c9f-b0da-beaa29322e5c)
![Screenshot 2024-06-06 at 06 13 43](https://github.com/animina-dating/animina/assets/86654131/aa34da69-fdb0-4240-b7aa-69dddf2284f4)


