### PR TITLE
Truncate long usernames and names in the GUI  , closes #653

### DIFF
--- a/lib/animina_web/components/bookmark/bookmarks_components.ex
+++ b/lib/animina_web/components/bookmark/bookmarks_components.ex
@@ -2,6 +2,7 @@ defmodule AniminaWeb.BookmarksComponents do
   @moduledoc """
   Provides Bookmark UI components.
   """
+  alias Animina.StringHelper
   use Phoenix.Component
   import AniminaWeb.Gettext
 
@@ -42,7 +43,7 @@ defmodule AniminaWeb.BookmarksComponents do
 
           <div class="space-y-2 w-[100%] flex-1">
             <h1 class=" font-medium dark:text-white">
-              <%= @bookmark.user.name %>
+              <%= StringHelper.truncate_name(@bookmark.user.name) %>
             </h1>
 
             <div

--- a/lib/animina_web/components/chat/chat_components.ex
+++ b/lib/animina_web/components/chat/chat_components.ex
@@ -4,6 +4,7 @@ defmodule AniminaWeb.ChatComponents do
   """
   use Phoenix.Component
   alias Animina.Markdown
+  alias Animina.StringHelper
   alias AniminaWeb.ProfileComponents
   import AniminaWeb.Gettext
 
@@ -126,7 +127,7 @@ defmodule AniminaWeb.ChatComponents do
         <.receiver_user_image user={@receiver} current_user={@sender} />
         <div class="justify-start flex items-start flex-col">
           <p class="dark:text-white">
-            <%= @receiver.name %>
+            <%= StringHelper.truncate_name(@receiver.name) %>
           </p>
           <div class="md:w-[300px w-[250px]   dark:bg-white bg-gray-300 text-black   flex flex-col gap-2 justify-between p-1 items-end rounded-md">
             <p>

--- a/lib/animina_web/components/dashboard/dashboard_components.ex
+++ b/lib/animina_web/components/dashboard/dashboard_components.ex
@@ -4,6 +4,7 @@ defmodule AniminaWeb.DashboardComponents do
   """
   use Phoenix.Component
   alias Animina.Markdown
+  alias Animina.StringHelper
   import AniminaWeb.Gettext
   import AniminaWeb.CoreComponents
   import Phoenix.HTML.Form
@@ -146,7 +147,7 @@ defmodule AniminaWeb.DashboardComponents do
         <.sender_user_image user={@sender} current_user={@receiver} />
         <div class="justify-start w-[100%] flex items-start flex-col">
           <p class="text-xs dark:text-white">
-            <%= @sender.name %>
+            <%= StringHelper.truncate_name(@sender.name) %>
           </p>
           <div class=" w-[100%]  text-xs   dark:bg-gray-100 bg-gray-300 text-black   flex flex-col gap-1 justify-between px-1 items-start rounded-md">
             <p class="px-1">

--- a/lib/animina_web/components/top_navigation_components.ex
+++ b/lib/animina_web/components/top_navigation_components.ex
@@ -7,6 +7,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
   import AniminaWeb.Gettext
   alias Animina.Accounts.Points
   alias Animina.Accounts.User
+  alias Animina.StringHelper
 
   # -------------------------------------------------------------
   @doc """
@@ -62,7 +63,9 @@ defmodule AniminaWeb.TopNavigationCompontents do
           class="flex cursor-pointer dark:text-white  gap-2 items-center"
         >
           <.user_avatar_image current_user={@current_user} />
-          <p :if={@current_user} class="md:block hidden"><%= @current_user.name %></p>
+          <p :if={@current_user} class="md:block hidden">
+            <%= StringHelper.truncate_name(@current_user.name) %>
+          </p>
 
           <button class="dark:text-white md:block hidden" type="button">
             <.arrow_down />
@@ -148,7 +151,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
           <div class="border-gray-100 border-b-[1px]  py-1">
             <p class="text-sm px-2 " role="none"><%= gettext("Signed in as") %></p>
             <p class="truncate text-sm px-2 font-medium dark:text-gray-400 text-gray-900">
-              <%= @current_user.username %>
+              <%= StringHelper.truncate_username(@current_user.username) %>
             </p>
           </div>
           <.link class="px-2" navigate="/my/flags/white">
@@ -269,7 +272,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
     <.error_or_nsfw_profile_image />
     <%end %>
     <p>
-        <%= @interest.name %>
+        <%= StringHelper.truncate_name(@interest.name) %>
     </p>
 
     </div>

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -8,6 +8,7 @@ defmodule AniminaWeb.DashboardLive do
   alias Animina.GenServers.ProfileViewCredits
   alias Animina.Markdown
   alias Animina.Narratives.Story
+  alias Animina.StringHelper
   alias Animina.Traits.UserFlags
   alias AshPhoenix.Form
   alias Phoenix.PubSub
@@ -400,7 +401,7 @@ defmodule AniminaWeb.DashboardLive do
                 </div>
 
                 <h3 class="mt-6 text-lg font-semibold leading-8 tracking-tight text-gray-900 dark:text-gray-300">
-                  <%= potential_partner.name %>
+                  <%= StringHelper.truncate_name(potential_partner.name) %>
                 </h3>
               </.link>
 

--- a/lib/animina_web/string_helper.ex
+++ b/lib/animina_web/string_helper.ex
@@ -36,6 +36,32 @@ defmodule Animina.StringHelper do
     end
   end
 
+  def truncate_username(str) do
+    str = Ash.CiString.value(str)
+
+    if String.length(str) <= 18 do
+      str
+    else
+      sliced_str =
+        str
+        |> String.slice(0, 18)
+
+      sliced_str <> "..."
+    end
+  end
+
+  def truncate_name(str) do
+    if String.length(str) <= 18 do
+      str
+    else
+      sliced_str =
+        str
+        |> String.slice(0, 18)
+
+      sliced_str <> "..."
+    end
+  end
+
   defp ensure_word_boundary(sliced_str) do
     words = String.split(sliced_str, ~r/\s+/)
 


### PR DESCRIPTION
- Hello @wintermeyer  , I added truncates to the following pages 
![Screenshot 2024-06-12 at 05 42 26](https://github.com/animina-dating/animina/assets/86654131/54acf502-f921-4662-82bb-880a650892e0)
![Screenshot 2024-06-12 at 05 43 48](https://github.com/animina-dating/animina/assets/86654131/ba1671f2-e065-4b52-a359-138f29555c6a)
![Screenshot 2024-06-12 at 05 44 10](https://github.com/animina-dating/animina/assets/86654131/c7ccac08-b613-4f66-b7db-bea3a08247c6)
![Screenshot 2024-06-12 at 05 44 28](https://github.com/animina-dating/animina/assets/86654131/bb28f86e-83fd-4e6b-92a0-0ebfad7a3b5b)
![Screenshot 2024-06-12 at 05 52 33](https://github.com/animina-dating/animina/assets/86654131/224f27bf-bde7-4e3a-93ff-caddf04cabe9)
![Screenshot 2024-06-12 at 05 53 13](https://github.com/animina-dating/animina/assets/86654131/2918b4a2-7fcb-44ef-91f8-aea26818e820)



I maintained long names and usernames for the following


![Screenshot 2024-06-12 at 05 38 00](https://github.com/animina-dating/animina/assets/86654131/0eb1cd7d-1599-4305-9763-56f2fbdd2449)
![Screenshot 2024-06-12 at 05 38 25](https://github.com/animina-dating/animina/assets/86654131/6d7037d5-ae83-46a5-bb19-a5e2910dc713)



PS , for this demo , I truncate at 6 to see how it would look like , but they are now truncated at 18.
