### PR TITLE
Under Investigation Profile Actions , closes #665

### DIFF
--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -143,15 +143,15 @@ defmodule Animina.Accounts.BasicUser do
     end
 
     update :validate do
-      change transition_state(:validate)
+      change transition_state(:validated)
     end
 
     update :investigate do
-      change transition_state(:investigate)
+      change transition_state(:under_investigation)
     end
 
     update :ban do
-      change transition_state(:ban)
+      change transition_state(:banned)
     end
 
     update :incognito do
@@ -163,19 +163,19 @@ defmodule Animina.Accounts.BasicUser do
     end
 
     update :archive do
-      change transition_state(:archive)
+      change transition_state(:archived)
     end
 
     update :reactivate do
-      change transition_state(:reactivate)
+      change transition_state(:normal)
     end
 
     update :unban do
-      change transition_state(:unban)
+      change transition_state(:normal)
     end
 
     update :recover do
-      change transition_state(:recover)
+      change transition_state(:normal)
     end
   end
 

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -6,7 +6,7 @@ defmodule Animina.Accounts.User do
   use Ash.Resource,
     data_layer: AshPostgres.DataLayer,
     authorizers: Ash.Policy.Authorizer,
-    extensions: [AshAuthentication, AshStateMachine]
+    extensions: [AshAuthentication, AshStateMachine, Ash.Notifier.PubSub]
 
   alias Animina.Accounts
   alias Animina.Narratives
@@ -184,6 +184,14 @@ defmodule Animina.Accounts.User do
       transition(:unban, from: [:banned], to: :normal)
       transition(:recover, from: [:archived], to: :normal)
     end
+  end
+
+  pub_sub do
+    module Animina
+    prefix "user"
+    broadcast_type :phoenix_broadcast
+
+    publish :update, ["updated", :id]
   end
 
   identities do

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -234,15 +234,15 @@ defmodule Animina.Accounts.User do
     end
 
     update :validate do
-      change transition_state(:validate)
+      change transition_state(:validated)
     end
 
     update :investigate do
-      change transition_state(:investigate)
+      change transition_state(:under_investigation)
     end
 
     update :ban do
-      change transition_state(:ban)
+      change transition_state(:banned)
     end
 
     update :incognito do
@@ -254,19 +254,19 @@ defmodule Animina.Accounts.User do
     end
 
     update :archive do
-      change transition_state(:archive)
+      change transition_state(:archived)
     end
 
     update :reactivate do
-      change transition_state(:reactivate)
+      change transition_state(:normal)
     end
 
     update :unban do
-      change transition_state(:unban)
+      change transition_state(:normal)
     end
 
     update :recover do
-      change transition_state(:recover)
+      change transition_state(:normal)
     end
   end
 
@@ -283,6 +283,7 @@ defmodule Animina.Accounts.User do
     define :custom_sign_in, get?: true
     define :female_public_users_who_created_an_account_in_the_last_60_days
     define :male_public_users_who_created_an_account_in_the_last_60_days
+    define :investigate
   end
 
   calculations do

--- a/lib/animina/action_points_list.ex
+++ b/lib/animina/action_points_list.ex
@@ -5,8 +5,12 @@ defmodule Animina.ActionPointsList do
 
   @action_points_list [
     %{
-      points: 100,
-      action: :view_profile
+      points: 10,
+      action: :first_private_profile_view_if_profile_has_liked_current_user
+    },
+    %{
+      points: 20,
+      action: :first_private_profile_view_if_profile_has_not_liked_current_user
     },
     %{
       points: 200,

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -12,26 +12,18 @@ defmodule Animina.Checks.ReadProfileCheck do
   end
 
   def match?(actor, params, _opts) do
-    IO.inspect params
-    IO.inspect check_if_user_can_view_profile(actor, params, params.query.arguments) , label: "Mamamia"
+    check_if_user_can_view_profile(actor, params, params.query.arguments)
   end
 
-  defp check_if_user_can_view_profile(_actor, _params, %{}) do
-    IO.inspect("Here s")
-    true
-  end
-
-  defp check_if_user_can_view_profile(actor, params, _) do
+  defp check_if_user_can_view_profile(actor, params, %{username: _username}) do
     case User.by_username(params.query.arguments.username) do
       {:ok, profile} ->
         if actor.username == profile.username || profile.is_private == false do
           user_can_view_profile(
             admin_user?(actor),
             profile.state
-
           )
         else
-          IO.puts("MAmma")
           user_can_view_profile(
             admin_user?(actor),
             profile.state,
@@ -46,6 +38,9 @@ defmodule Animina.Checks.ReadProfileCheck do
     end
   end
 
+  defp check_if_user_can_view_profile(_actor, _params, _) do
+    true
+  end
 
   defp user_can_view_profile(true, :normal) do
     true
@@ -62,6 +57,7 @@ defmodule Animina.Checks.ReadProfileCheck do
   defp user_can_view_profile(_, _) do
     true
   end
+
   defp user_can_view_profile(true, :normal_, _, _) do
     true
   end

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -115,6 +115,34 @@ defmodule AniminaWeb.AuthController do
     end
   end
 
+  def sign_out(conn, %{"auto_log_out" => _}) do
+    return_to = get_session(conn, :return_to) || ~p"/sign-in"
+
+    token = Plug.Conn.get_session(conn, "user_token")
+
+    if token do
+      Token
+      |> TokenResource.Actions.get_token(%{"token" => token})
+      |> case do
+        {:ok, [token]} ->
+          Token.destroy!(token, authorize?: false)
+
+        _ ->
+          :ok
+      end
+    end
+
+    conn
+    |> clear_session()
+    |> put_flash(
+      :info,
+      gettext(
+        "Your account is currently under investigation. Please try again to login in 24 hours."
+      )
+    )
+    |> redirect(to: return_to)
+  end
+
   def sign_out(conn, _params) do
     return_to = get_session(conn, :return_to) || ~p"/sign-in"
 
@@ -134,6 +162,7 @@ defmodule AniminaWeb.AuthController do
 
     conn
     |> clear_session()
+    |> put_flash(:info, gettext("You have signed out successfully"))
     |> redirect(to: return_to)
   end
 

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -103,11 +103,13 @@ defmodule AniminaWeb.AuthController do
         |> assign(:current_user, user)
         |> redirect(to: return_to)
 
-      _ ->
+      {:error, body} ->
+        message = (body.errors |> List.first()).caused_by.message
+
         conn
         |> put_flash(
           :error,
-          gettext("Username or password is incorrect")
+          message
         )
         |> redirect(to: "/sign-in")
     end

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -239,7 +239,15 @@ defmodule AniminaWeb.ChatLive do
 
   def handle_info({:user, current_user}, socket) do
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -238,17 +238,12 @@ defmodule AniminaWeb.ChatLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    if current_user.id == socket.assigns.receiver.id do
-      {:noreply,
-       socket
-       |> assign(sender: current_user)
-       |> assign(
-         current_user_has_liked_profile?:
-           current_user_has_liked_profile(current_user.id, socket.assigns.receiver.id)
-       )}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
     else
       {:noreply,
        socket
+       |> assign(sender: current_user)
        |> assign(
          current_user_has_liked_profile?:
            current_user_has_liked_profile(current_user.id, socket.assigns.receiver.id)
@@ -397,6 +392,12 @@ defmodule AniminaWeb.ChatLive do
     Enum.filter(first_flag_array, fn x ->
       x.id in Enum.map(second_flag_array, fn x -> x.id end)
     end)
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   defp create_message_form do

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -197,9 +197,13 @@ defmodule AniminaWeb.DashboardLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    {:noreply,
-     socket
-     |> assign(current_user: current_user)}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply,
+       socket
+       |> assign(current_user: current_user)}
+    end
   end
 
   @impl true
@@ -343,6 +347,12 @@ defmodule AniminaWeb.DashboardLive do
       _ ->
         []
     end
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   @impl true

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -198,7 +198,15 @@ defmodule AniminaWeb.DashboardLive do
 
   def handle_info({:user, current_user}, socket) do
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -200,7 +200,15 @@ defmodule AniminaWeb.FlagsLive do
     flags = filter_flags(current_user, socket.assigns.color)
 
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -199,22 +199,26 @@ defmodule AniminaWeb.FlagsLive do
   def handle_info({:user, current_user}, socket) do
     flags = filter_flags(current_user, socket.assigns.color)
 
-    {:noreply,
-     socket
-     |> assign(current_user: current_user)
-     |> assign(
-       :opposite_color_flags_selected,
-       filter_flags(current_user, socket.assigns.color)
-       |> Enum.map(fn trait -> trait.flag.id end)
-     )
-     |> assign(
-       :user_flags,
-       flags
-     )
-     |> assign(
-       :selected,
-       Enum.count(flags)
-     )}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply,
+       socket
+       |> assign(current_user: current_user)
+       |> assign(
+         :opposite_color_flags_selected,
+         filter_flags(current_user, socket.assigns.color)
+         |> Enum.map(fn trait -> trait.flag.id end)
+       )
+       |> assign(
+         :user_flags,
+         flags
+       )
+       |> assign(
+         :selected,
+         Enum.count(flags)
+       )}
+    end
   end
 
   @impl true
@@ -285,6 +289,12 @@ defmodule AniminaWeb.FlagsLive do
     Traits.Category
     |> Ash.Query.for_read(:read)
     |> Traits.read!()
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   defp filter_flags(current_user, color) do

--- a/lib/animina_web/live/post_live.ex
+++ b/lib/animina_web/live/post_live.ex
@@ -75,7 +75,11 @@ defmodule AniminaWeb.PostLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    {:noreply, socket |> assign(:current_user, current_user)}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply, socket |> assign(:current_user, current_user)}
+    end
   end
 
   def handle_info({:new_message, message}, socket) do
@@ -156,6 +160,12 @@ defmodule AniminaWeb.PostLive do
       errors ->
         {:noreply, socket |> assign(:errors, errors)}
     end
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   @impl true

--- a/lib/animina_web/live/post_live.ex
+++ b/lib/animina_web/live/post_live.ex
@@ -76,7 +76,15 @@ defmodule AniminaWeb.PostLive do
 
   def handle_info({:user, current_user}, socket) do
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply, socket |> assign(:current_user, current_user)}
     end

--- a/lib/animina_web/live/post_view_live.ex
+++ b/lib/animina_web/live/post_view_live.ex
@@ -62,7 +62,15 @@ defmodule AniminaWeb.PostViewLive do
 
   def handle_info({:user, current_user}, socket) do
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply, socket |> assign(:current_user, current_user)}
     end

--- a/lib/animina_web/live/post_view_live.ex
+++ b/lib/animina_web/live/post_view_live.ex
@@ -61,7 +61,11 @@ defmodule AniminaWeb.PostViewLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    {:noreply, socket |> assign(:current_user, current_user)}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply, socket |> assign(:current_user, current_user)}
+    end
   end
 
   def handle_info({:new_message, message}, socket) do
@@ -71,6 +75,12 @@ defmodule AniminaWeb.PostViewLive do
      socket
      |> assign(unread_messages: unread_messages)
      |> assign(number_of_unread_messages: Enum.count(unread_messages))}
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   @impl true

--- a/lib/animina_web/live/potential_partner_live.ex
+++ b/lib/animina_web/live/potential_partner_live.ex
@@ -111,7 +111,11 @@ defmodule AniminaWeb.PotentialPartnerLive do
       |> assign(city_name: City.by_zip_code!(current_user.zip_code))
       |> assign(current_user: current_user)
 
-    {:noreply, socket}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply, socket}
+    end
   end
 
   @impl true
@@ -139,6 +143,12 @@ defmodule AniminaWeb.PotentialPartnerLive do
       _ ->
         {:noreply, assign(socket, update_form: form)}
     end
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   @impl true

--- a/lib/animina_web/live/potential_partner_live.ex
+++ b/lib/animina_web/live/potential_partner_live.ex
@@ -112,7 +112,15 @@ defmodule AniminaWeb.PotentialPartnerLive do
       |> assign(current_user: current_user)
 
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply, socket}
     end

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -428,7 +428,15 @@ defmodule AniminaWeb.ProfileLive do
 
   def handle_info({:user, current_user}, socket) do
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -108,7 +108,7 @@ defmodule AniminaWeb.ProfileLive do
 
     case Accounts.User.by_username(username) do
       {:ok, user} ->
-        if show_optional_404_page(user, nil) do
+        if show_optional_404_page(user, nil) || user.state == :under_investigation do
           raise Animina.Fallback
         else
           {:ok,

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -427,12 +427,16 @@ defmodule AniminaWeb.ProfileLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    {:noreply,
-     socket
-     |> assign(
-       current_user_has_liked_profile?:
-         current_user_has_liked_profile(current_user, socket.assigns.user.id)
-     )}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply,
+       socket
+       |> assign(
+         current_user_has_liked_profile?:
+           current_user_has_liked_profile(current_user, socket.assigns.user.id)
+       )}
+    end
   end
 
   def handle_info(
@@ -558,6 +562,12 @@ defmodule AniminaWeb.ProfileLive do
       Reaction.by_sender_and_receiver_id(user_id, current_user_id)
 
     reaction
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   @impl true

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -54,9 +54,13 @@ defmodule AniminaWeb.ProfilePhotoLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    {:noreply,
-     socket
-     |> assign(current_user: current_user)}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply,
+       socket
+       |> assign(current_user: current_user)}
+    end
   end
 
   @impl true
@@ -135,6 +139,12 @@ defmodule AniminaWeb.ProfilePhotoLive do
        :form,
        Form.for_create(Photo, :create, api: Accounts, as: "photo")
      )}
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   @impl true

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -55,7 +55,15 @@ defmodule AniminaWeb.ProfilePhotoLive do
 
   def handle_info({:user, current_user}, socket) do
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -102,7 +102,11 @@ defmodule AniminaWeb.StoryLive do
   end
 
   def handle_info({:user, current_user}, socket) do
-    {:noreply, socket |> assign(:current_user, current_user)}
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+    else
+      {:noreply, socket |> assign(:current_user, current_user)}
+    end
   end
 
   def handle_info({:new_message, message}, socket) do
@@ -390,6 +394,12 @@ defmodule AniminaWeb.StoryLive do
         disabled: Map.get(user_headlines, headline.id) != nil
       ]
     end)
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation
+    ]
   end
 
   defp get_default_headline(socket) when socket.assigns.live_action == :about_me do

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -103,7 +103,15 @@ defmodule AniminaWeb.StoryLive do
 
   def handle_info({:user, current_user}, socket) do
     if current_user.state in user_states_to_be_auto_logged_out() do
-      {:noreply, socket |> push_redirect(to: "/auth/user/sign-out")}
+      {:noreply,
+       socket
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
+       |> put_flash(
+         :error,
+         gettext(
+           "Your account is currently under investigation. Please try again to login in 24 hours."
+         )
+       )}
     else
       {:noreply, socket |> assign(:current_user, current_user)}
     end

--- a/lib/animina_web/potential_partner.ex
+++ b/lib/animina_web/potential_partner.ex
@@ -44,9 +44,15 @@ defmodule AniminaWeb.PotentialPartner do
     # |> partner_green_flags_query(user)
     # |> partner_red_flags_query(user, strict_red_flags)
     |> partner_not_self_query(user)
+    |> partner_not_under_investigation_query(user)
     |> partner_bookmarked_query(user, remove_bookmarked)
     |> Ash.Query.limit(limit)
     |> Accounts.read!()
+  end
+
+  defp partner_not_under_investigation_query(query, _user) do
+    query
+    |> Ash.Query.filter(state: [not_eq: :under_investigation])
   end
 
   defp partner_not_self_query(query, user) do

--- a/test/animina_web/live/bookmark_test.exs
+++ b/test/animina_web/live/bookmark_test.exs
@@ -1,6 +1,7 @@
 defmodule AniminaWeb.BookmarkTest do
   use AniminaWeb.ConnCase
   import Phoenix.LiveViewTest
+  alias Animina.Accounts.Credit
   alias Animina.Accounts.User
 
   describe "Tests the Bookmark Live" do
@@ -8,6 +9,18 @@ defmodule AniminaWeb.BookmarkTest do
       public_user = create_public_user()
 
       private_user = create_private_user()
+
+      Credit.create!(%{
+        user_id: private_user.id,
+        points: 100,
+        subject: "Registration bonus"
+      })
+
+      Credit.create!(%{
+        user_id: public_user.id,
+        points: 100,
+        subject: "Registration bonus"
+      })
 
       [
         public_user: public_user,

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -234,6 +234,8 @@ defmodule AniminaWeb.ProfileTest do
           }),
           "/#{public_user.username}"
         )
+
+      assert response(conn, 200)
     end
 
     test "Users Under Investigation are automatically logged out", %{

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -167,6 +167,21 @@ defmodule AniminaWeb.RootTest do
 
       assert has_element?(index_live, "#current-user-credit-points", "#{updated_points}")
     end
+
+    test "A user cannot login  if an account is under investigation", %{conn: conn} do
+      {:ok, user} = User.create(@valid_create_user_attrs)
+
+      {:ok, user} = User.investigate(user)
+
+      {:error,
+       {:redirect,
+        %{to: "/sign-in?redirect_to=/my/potential-partner/", flash: %{"error" => error}}}} =
+        conn
+        |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
+        |> live(~p"/my/potential-partner/")
+
+      assert error == "Account is under investigation"
+    end
   end
 
   defp sign_in_user(conn, attributes) do


### PR DESCRIPTION
In this PR , I did the following and wrote unit and integration tests for them.
For users who are under investigation..
  

- [x] They cannot log in
- [x]   People cannot view their profile
- [x]   Admins Can view their profile
- [x]  They are immediately logged out
- [x]  We do not use them in the potential partners query


@wintermeyer  , If a user who is under investigation tries to sign in , and they add a correct password , we show an error , `Account is under investigation` .
![Screenshot 2024-06-16 at 08 57 29](https://github.com/animina-dating/animina/assets/86654131/8a623d46-d2b2-4c41-82d7-778f8edded64)


When a user state changes to :under_investigation , they are automatically logged out


https://github.com/animina-dating/animina/assets/86654131/40faacf1-504e-4ada-ae98-7ba1bd94f2d3


