### PR TITLE
Banned user actions , closes #667

### DIFF
--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -185,6 +185,8 @@ defmodule Animina.Accounts.BasicUser do
     define :create
     define :by_id, get_by: [:id], action: :read
     define :custom_sign_in, get?: true
+    define :investigate
+    define :ban
   end
 
   aggregates do

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -292,6 +292,7 @@ defmodule Animina.Accounts.User do
     define :female_public_users_who_created_an_account_in_the_last_60_days
     define :male_public_users_who_created_an_account_in_the_last_60_days
     define :investigate
+    define :ban
   end
 
   calculations do

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -51,7 +51,15 @@ defmodule Animina.Checks.ReadProfileCheck do
     true
   end
 
+  defp user_can_view_profile(true, :banned) do
+    true
+  end
+
   defp user_can_view_profile(false, :under_investigation) do
+    false
+  end
+
+  defp user_can_view_profile(false, :banned) do
     false
   end
 
@@ -68,6 +76,14 @@ defmodule Animina.Checks.ReadProfileCheck do
   end
 
   defp user_can_view_profile(false, :under_investigation, _, _, _) do
+    false
+  end
+
+  defp user_can_view_profile(true, :banned_, _, _) do
+    true
+  end
+
+  defp user_can_view_profile(false, :banned_, _, _) do
     false
   end
 

--- a/lib/animina/custom_sign_in_preparation.ex
+++ b/lib/animina/custom_sign_in_preparation.ex
@@ -63,7 +63,7 @@ defmodule Animina.MyCustomSignInPreparation do
                module: __MODULE__,
                action: query.action,
                resource: query.resource,
-               message: gettext("Account is banned")
+               message: gettext("Account is banned, Kindly Contact Support")
              }
            )}
 

--- a/lib/animina/custom_sign_in_preparation.ex
+++ b/lib/animina/custom_sign_in_preparation.ex
@@ -15,6 +15,7 @@ defmodule Animina.MyCustomSignInPreparation do
   use Ash.Resource.Preparation
   alias Ash.Query
   require Ash.Query
+  import AniminaWeb.Gettext
   alias AshAuthentication.{Errors.AuthenticationFailed, Jwt}
 
   @doc false
@@ -49,7 +50,20 @@ defmodule Animina.MyCustomSignInPreparation do
                module: __MODULE__,
                action: query.action,
                resource: query.resource,
-               message: "Account is under investigation"
+               message:
+                 gettext("Account is under investigation, kindly try and log in after 24 hours")
+             }
+           )}
+
+        :banned ->
+          {:error,
+           AuthenticationFailed.exception(
+             query: query,
+             caused_by: %{
+               module: __MODULE__,
+               action: query.action,
+               resource: query.resource,
+               message: gettext("Account is banned")
              }
            )}
 

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -115,7 +115,7 @@ defmodule AniminaWeb.AuthController do
     end
   end
 
-  def sign_out(conn, %{"auto_log_out" => _}) do
+  def sign_out(conn, %{"auto_log_out" => state}) do
     return_to = get_session(conn, :return_to) || ~p"/sign-in"
 
     token = Plug.Conn.get_session(conn, "user_token")
@@ -136,9 +136,7 @@ defmodule AniminaWeb.AuthController do
     |> clear_session()
     |> put_flash(
       :info,
-      gettext(
-        "Your account is currently under investigation. Please try again to login in 24 hours."
-      )
+      get_auto_logout_text(state)
     )
     |> redirect(to: return_to)
   end
@@ -164,6 +162,21 @@ defmodule AniminaWeb.AuthController do
     |> clear_session()
     |> put_flash(:info, gettext("You have signed out successfully"))
     |> redirect(to: return_to)
+  end
+
+  defp get_auto_logout_text(state) do
+    case state do
+      "under_investigation" ->
+        gettext(
+          "Your account is currently under investigation. Please try again to login in 24 hours."
+        )
+
+      "banned" ->
+        gettext("Your account has been banned. Please contact support for more information.")
+
+      _ ->
+        gettext("Your account has been banned. Please contact support for more information.")
+    end
   end
 
   defp redirect_url(user) do

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -135,7 +135,7 @@ defmodule AniminaWeb.AuthController do
     conn
     |> clear_session()
     |> put_flash(
-      :info,
+      :error,
       get_auto_logout_text(state)
     )
     |> redirect(to: return_to)

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -241,13 +241,7 @@ defmodule AniminaWeb.ChatLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -404,7 +404,8 @@ defmodule AniminaWeb.ChatLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -200,13 +200,7 @@ defmodule AniminaWeb.DashboardLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -359,7 +359,8 @@ defmodule AniminaWeb.DashboardLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -301,7 +301,8 @@ defmodule AniminaWeb.FlagsLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -202,13 +202,7 @@ defmodule AniminaWeb.FlagsLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/post_live.ex
+++ b/lib/animina_web/live/post_live.ex
@@ -172,7 +172,8 @@ defmodule AniminaWeb.PostLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/post_live.ex
+++ b/lib/animina_web/live/post_live.ex
@@ -78,13 +78,7 @@ defmodule AniminaWeb.PostLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply, socket |> assign(:current_user, current_user)}
     end

--- a/lib/animina_web/live/post_view_live.ex
+++ b/lib/animina_web/live/post_view_live.ex
@@ -87,7 +87,8 @@ defmodule AniminaWeb.PostViewLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/post_view_live.ex
+++ b/lib/animina_web/live/post_view_live.ex
@@ -64,13 +64,7 @@ defmodule AniminaWeb.PostViewLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply, socket |> assign(:current_user, current_user)}
     end
@@ -90,6 +84,21 @@ defmodule AniminaWeb.PostViewLive do
       :under_investigation,
       :banned
     ]
+  end
+
+  defp get_auto_logout_text(state) do
+    case state do
+      :under_investigation ->
+        gettext(
+          "Your account is currently under investigation. Please try again to login in 24 hours."
+        )
+
+      :banned ->
+        gettext("Your account has been banned. Please contact support for more information.")
+
+      _ ->
+        gettext("Your account has been banned. Please contact support for more information.")
+    end
   end
 
   @impl true

--- a/lib/animina_web/live/potential_partner_live.ex
+++ b/lib/animina_web/live/potential_partner_live.ex
@@ -155,7 +155,8 @@ defmodule AniminaWeb.PotentialPartnerLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/potential_partner_live.ex
+++ b/lib/animina_web/live/potential_partner_live.ex
@@ -114,13 +114,7 @@ defmodule AniminaWeb.PotentialPartnerLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply, socket}
     end

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -430,13 +430,7 @@ defmodule AniminaWeb.ProfileLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply,
        socket

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -108,7 +108,7 @@ defmodule AniminaWeb.ProfileLive do
 
     case Accounts.User.by_username(username) do
       {:ok, user} ->
-        if show_optional_404_page(user, nil) || user.state == :under_investigation do
+        if show_optional_404_page(user, nil) || user.state in user_states_to_be_auto_logged_out() do
           raise Animina.Fallback
         else
           {:ok,
@@ -574,7 +574,8 @@ defmodule AniminaWeb.ProfileLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -151,7 +151,8 @@ defmodule AniminaWeb.ProfilePhotoLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -57,13 +57,7 @@ defmodule AniminaWeb.ProfilePhotoLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply,
        socket
@@ -154,6 +148,21 @@ defmodule AniminaWeb.ProfilePhotoLive do
       :under_investigation,
       :banned
     ]
+  end
+
+  defp get_auto_logout_text(state) do
+    case state do
+      :under_investigation ->
+        gettext(
+          "Your account is currently under investigation. Please try again to login in 24 hours."
+        )
+
+      :banned ->
+        gettext("Your account has been banned. Please contact support for more information.")
+
+      _ ->
+        gettext("Your account has been banned. Please contact support for more information.")
+    end
   end
 
   @impl true

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -406,7 +406,8 @@ defmodule AniminaWeb.StoryLive do
 
   defp user_states_to_be_auto_logged_out do
     [
-      :under_investigation
+      :under_investigation,
+      :banned
     ]
   end
 

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -105,13 +105,7 @@ defmodule AniminaWeb.StoryLive do
     if current_user.state in user_states_to_be_auto_logged_out() do
       {:noreply,
        socket
-       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=true")
-       |> put_flash(
-         :error,
-         gettext(
-           "Your account is currently under investigation. Please try again to login in 24 hours."
-         )
-       )}
+       |> push_redirect(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
     else
       {:noreply, socket |> assign(:current_user, current_user)}
     end

--- a/lib/animina_web/potential_partner.ex
+++ b/lib/animina_web/potential_partner.ex
@@ -45,6 +45,7 @@ defmodule AniminaWeb.PotentialPartner do
     # |> partner_red_flags_query(user, strict_red_flags)
     |> partner_not_self_query(user)
     |> partner_not_under_investigation_query(user)
+    |> partner_not_banned_query(user)
     |> partner_bookmarked_query(user, remove_bookmarked)
     |> Ash.Query.limit(limit)
     |> Accounts.read!()
@@ -53,6 +54,11 @@ defmodule AniminaWeb.PotentialPartner do
   defp partner_not_under_investigation_query(query, _user) do
     query
     |> Ash.Query.filter(state: [not_eq: :under_investigation])
+  end
+
+  defp partner_not_banned_query(query, _user) do
+    query
+    |> Ash.Query.filter(state: [not_eq: :banned])
   end
 
   defp partner_not_self_query(query, user) do

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -214,6 +214,17 @@ defmodule AniminaWeb.ProfileTest do
       end
     end
 
+    test "If an account is banned , the profile returns a 404", %{
+      conn: conn,
+      public_user: public_user
+    } do
+      {:ok, user} = User.ban(public_user)
+
+      assert_raise Animina.Fallback, fn ->
+        get(conn, "/#{user.username}") |> response(404)
+      end
+    end
+
     test "If an account is under investigation , admins can view that profile", %{
       conn: conn,
       public_user: public_user,
@@ -236,6 +247,53 @@ defmodule AniminaWeb.ProfileTest do
         )
 
       assert response(conn, 200)
+    end
+
+    test "If an account is banned , admins can view that profile", %{
+      conn: conn,
+      public_user: public_user,
+      private_user: private_user
+    } do
+      {:ok, _user} = User.ban(public_user)
+
+      admin_role = create_admin_role()
+
+      create_admin_user_role(private_user.id, admin_role.id)
+
+      conn =
+        get(
+          conn
+          |> login_user(%{
+            "username_or_email" => private_user.username,
+            "password" => "MichaelTheEngineer"
+          }),
+          "/#{public_user.username}"
+        )
+
+      assert response(conn, 200)
+    end
+
+    test "Users That Are Banned are automatically logged out", %{
+      conn: conn,
+      private_user: private_user,
+      public_user: public_user
+    } do
+      {:ok, _index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => public_user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/#{private_user.username}")
+
+      assert html =~ private_user.name
+
+      {:ok, user} = User.ban(private_user)
+
+      # now you cannot access the private profile which means you are logged out
+      assert_raise Animina.Fallback, fn ->
+        get(conn, "/#{user.username}") |> response(404)
+      end
     end
 
     test "Users Under Investigation are automatically logged out", %{

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -180,7 +180,22 @@ defmodule AniminaWeb.RootTest do
         |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
         |> live(~p"/my/potential-partner/")
 
-      assert error == "Account is under investigation"
+      assert error == "Account is under investigation, kindly try and log in after 24 hours"
+    end
+
+    test "A user cannot login  if an account is banned", %{conn: conn} do
+      {:ok, user} = User.create(@valid_create_user_attrs)
+
+      {:ok, user} = User.ban(user)
+
+      {:error,
+       {:redirect,
+        %{to: "/sign-in?redirect_to=/my/potential-partner/", flash: %{"error" => error}}}} =
+        conn
+        |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
+        |> live(~p"/my/potential-partner/")
+
+      assert error == "Account is banned"
     end
   end
 

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -195,7 +195,7 @@ defmodule AniminaWeb.RootTest do
         |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
         |> live(~p"/my/potential-partner/")
 
-      assert error == "Account is banned"
+      assert error == "Account is banned, Kindly Contact Support"
     end
   end
 


### PR DESCRIPTION
Tasks are the following

- For a profile that is banned , 

- [x] They cannot log in
- [x] People cannot view their profile
- [x] Admins Can view their profile
- [x] They are immediately logged out
- [x] We do not use them in the potential partners query


@wintermeyer  , they get the flash below once they are auto logged out

![Screenshot 2024-06-17 at 06 32 21](https://github.com/animina-dating/animina/assets/86654131/c32f6e77-65c4-4c5f-b030-7b9ab3927cb8)

And the following if they try to login with correct details


![Screenshot 2024-06-17 at 11 18 37](https://github.com/animina-dating/animina/assets/86654131/d221c1c6-cb01-471a-962c-a3c646f8359c)

