### PR TITLE
Added tests and functionalities for an archived user , closes #669

### DIFF
--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -187,6 +187,7 @@ defmodule Animina.Accounts.BasicUser do
     define :custom_sign_in, get?: true
     define :investigate
     define :ban
+    define :archive
   end
 
   aggregates do

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -293,6 +293,7 @@ defmodule Animina.Accounts.User do
     define :male_public_users_who_created_an_account_in_the_last_60_days
     define :investigate
     define :ban
+    define :archive
   end
 
   calculations do

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -55,6 +55,10 @@ defmodule Animina.Checks.ReadProfileCheck do
     true
   end
 
+  defp user_can_view_profile(true, :archived) do
+    true
+  end
+
   defp user_can_view_profile(false, :under_investigation) do
     false
   end
@@ -63,29 +67,42 @@ defmodule Animina.Checks.ReadProfileCheck do
     false
   end
 
+  defp user_can_view_profile(false, :archived) do
+    false
+  end
+
   defp user_can_view_profile(_, _) do
     true
   end
 
-  defp user_can_view_profile(true, :normal, _, _) do
+
+
+  defp user_can_view_profile(true, :under_investigation, _, _,_) do
     true
   end
 
-  defp user_can_view_profile(true, :under_investigation_, _, _) do
-    true
-  end
-
-  defp user_can_view_profile(false, :under_investigation, _, _, _) do
+  defp user_can_view_profile(false, :under_investigation, _, _,_) do
     false
   end
 
-  defp user_can_view_profile(true, :banned_, _, _) do
+  defp user_can_view_profile(true, :banned, _, _,_) do
     true
   end
 
-  defp user_can_view_profile(false, :banned_, _, _) do
+  defp user_can_view_profile(false, :banned, _, _,_) do
     false
   end
+
+
+  defp user_can_view_profile(true, :archived, _, _,_) do
+    true
+  end
+
+  defp user_can_view_profile(false, :archived, _, _,_) do
+    false
+  end
+
+
 
   defp user_can_view_profile(false, _, false, profile_liked, points) do
     if profile_liked do
@@ -96,6 +113,10 @@ defmodule Animina.Checks.ReadProfileCheck do
   end
 
   defp user_can_view_profile(false, _, _, _, _) do
+    false
+  end
+
+  defp user_can_view_profile(true, _, _, _, _) do
     false
   end
 

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -75,34 +75,29 @@ defmodule Animina.Checks.ReadProfileCheck do
     true
   end
 
-
-
-  defp user_can_view_profile(true, :under_investigation, _, _,_) do
+  defp user_can_view_profile(true, :under_investigation, _, _, _) do
     true
   end
 
-  defp user_can_view_profile(false, :under_investigation, _, _,_) do
+  defp user_can_view_profile(false, :under_investigation, _, _, _) do
     false
   end
 
-  defp user_can_view_profile(true, :banned, _, _,_) do
+  defp user_can_view_profile(true, :banned, _, _, _) do
     true
   end
 
-  defp user_can_view_profile(false, :banned, _, _,_) do
+  defp user_can_view_profile(false, :banned, _, _, _) do
     false
   end
 
-
-  defp user_can_view_profile(true, :archived, _, _,_) do
+  defp user_can_view_profile(true, :archived, _, _, _) do
     true
   end
 
-  defp user_can_view_profile(false, :archived, _, _,_) do
+  defp user_can_view_profile(false, :archived, _, _, _) do
     false
   end
-
-
 
   defp user_can_view_profile(false, _, false, profile_liked, points) do
     if profile_liked do

--- a/lib/animina/custom_sign_in_preparation.ex
+++ b/lib/animina/custom_sign_in_preparation.ex
@@ -67,6 +67,18 @@ defmodule Animina.MyCustomSignInPreparation do
              }
            )}
 
+        :archived ->
+          {:error,
+           AuthenticationFailed.exception(
+             query: query,
+             caused_by: %{
+               module: __MODULE__,
+               action: query.action,
+               resource: query.resource,
+               message: gettext("Account is archived, Kindly Contact Support")
+             }
+           )}
+
         _ ->
           {:ok,
            [

--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -174,6 +174,9 @@ defmodule AniminaWeb.AuthController do
       "banned" ->
         gettext("Your account has been banned. Please contact support for more information.")
 
+      "archived" ->
+        gettext("Your account has been archived")
+
       _ ->
         gettext("Your account has been banned. Please contact support for more information.")
     end

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -399,7 +399,8 @@ defmodule AniminaWeb.ChatLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 

--- a/lib/animina_web/live/dashboard_live.ex
+++ b/lib/animina_web/live/dashboard_live.ex
@@ -354,7 +354,8 @@ defmodule AniminaWeb.DashboardLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 

--- a/lib/animina_web/live/flags_live.ex
+++ b/lib/animina_web/live/flags_live.ex
@@ -296,7 +296,8 @@ defmodule AniminaWeb.FlagsLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 

--- a/lib/animina_web/live/post_live.ex
+++ b/lib/animina_web/live/post_live.ex
@@ -167,7 +167,8 @@ defmodule AniminaWeb.PostLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 

--- a/lib/animina_web/live/post_view_live.ex
+++ b/lib/animina_web/live/post_view_live.ex
@@ -82,23 +82,9 @@ defmodule AniminaWeb.PostViewLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
-  end
-
-  defp get_auto_logout_text(state) do
-    case state do
-      :under_investigation ->
-        gettext(
-          "Your account is currently under investigation. Please try again to login in 24 hours."
-        )
-
-      :banned ->
-        gettext("Your account has been banned. Please contact support for more information.")
-
-      _ ->
-        gettext("Your account has been banned. Please contact support for more information.")
-    end
   end
 
   @impl true

--- a/lib/animina_web/live/potential_partner_live.ex
+++ b/lib/animina_web/live/potential_partner_live.ex
@@ -150,7 +150,8 @@ defmodule AniminaWeb.PotentialPartnerLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -569,7 +569,8 @@ defmodule AniminaWeb.ProfileLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -146,24 +146,12 @@ defmodule AniminaWeb.ProfilePhotoLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 
-  defp get_auto_logout_text(state) do
-    case state do
-      :under_investigation ->
-        gettext(
-          "Your account is currently under investigation. Please try again to login in 24 hours."
-        )
 
-      :banned ->
-        gettext("Your account has been banned. Please contact support for more information.")
-
-      _ ->
-        gettext("Your account has been banned. Please contact support for more information.")
-    end
-  end
 
   @impl true
   def render(assigns) do

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -151,8 +151,6 @@ defmodule AniminaWeb.ProfilePhotoLive do
     ]
   end
 
-
-
   @impl true
   def render(assigns) do
     ~H"""

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -401,7 +401,8 @@ defmodule AniminaWeb.StoryLive do
   defp user_states_to_be_auto_logged_out do
     [
       :under_investigation,
-      :banned
+      :banned,
+      :archived
     ]
   end
 

--- a/lib/animina_web/potential_partner.ex
+++ b/lib/animina_web/potential_partner.ex
@@ -61,6 +61,11 @@ defmodule AniminaWeb.PotentialPartner do
     |> Ash.Query.filter(state: [not_eq: :banned])
   end
 
+  defp partner_not_archived_query(query, _user) do
+    query
+    |> Ash.Query.filter(state: [not_eq: :archived])
+  end
+
   defp partner_not_self_query(query, user) do
     query
     |> Ash.Query.filter(id: [not_eq: user.id])

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -225,7 +225,6 @@ defmodule AniminaWeb.ProfileTest do
       end
     end
 
-
     test "If an account is archived , the profile returns a 404", %{
       conn: conn,
       public_user: public_user

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -197,6 +197,21 @@ defmodule AniminaWeb.RootTest do
 
       assert error == "Account is banned, Kindly Contact Support"
     end
+
+    test "A user cannot login  if an account is archived", %{conn: conn} do
+      {:ok, user} = User.create(@valid_create_user_attrs)
+
+      {:ok, user} = User.archive(user)
+
+      {:error,
+       {:redirect,
+        %{to: "/sign-in?redirect_to=/my/potential-partner/", flash: %{"error" => error}}}} =
+        conn
+        |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
+        |> live(~p"/my/potential-partner/")
+
+      assert error == "Account is archived, Kindly Contact Support"
+    end
   end
 
   defp sign_in_user(conn, attributes) do


### PR DESCRIPTION
Tasks are the following

For a profile that is archived ,

- [x] They cannot log in
- [x] People cannot view their profile
- [x] Admins Can view their profile
- [x] They are immediately logged out
- [x] We do not use them in the potential partners query

![Screenshot 2024-06-18 at 07 03 15](https://github.com/animina-dating/animina/assets/86654131/66055a36-6096-4fa5-b2cb-af940d0b9716)




