### PR TITLE
Added tests and functionalities for hibernate, closes #671

### DIFF
--- a/lib/animina/accounts/resources/basic_user.ex
+++ b/lib/animina/accounts/resources/basic_user.ex
@@ -188,6 +188,7 @@ defmodule Animina.Accounts.BasicUser do
     define :investigate
     define :ban
     define :archive
+    define :hibernate
   end
 
   aggregates do

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -294,6 +294,7 @@ defmodule Animina.Accounts.User do
     define :investigate
     define :ban
     define :archive
+    define :hibernate
   end
 
   calculations do

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -59,6 +59,10 @@ defmodule Animina.Checks.ReadProfileCheck do
     true
   end
 
+  defp user_can_view_profile(true, :hibernate) do
+    true
+  end
+
   defp user_can_view_profile(false, :under_investigation) do
     false
   end
@@ -68,6 +72,10 @@ defmodule Animina.Checks.ReadProfileCheck do
   end
 
   defp user_can_view_profile(false, :archived) do
+    false
+  end
+
+  defp user_can_view_profile(false, :hibernate) do
     false
   end
 
@@ -96,6 +104,14 @@ defmodule Animina.Checks.ReadProfileCheck do
   end
 
   defp user_can_view_profile(false, :archived, _, _, _) do
+    false
+  end
+
+  defp user_can_view_profile(true, :hibernate, _, _, _) do
+    true
+  end
+
+  defp user_can_view_profile(false, :hibernate, _, _, _) do
     false
   end
 

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -108,7 +108,8 @@ defmodule AniminaWeb.ProfileLive do
 
     case Accounts.User.by_username(username) do
       {:ok, user} ->
-        if show_optional_404_page(user, nil) || user.state in user_states_to_be_auto_logged_out() do
+        if show_optional_404_page(user, nil) ||
+             user.state in user_states_not_visible_to_anonymous_users() do
           raise Animina.Fallback
         else
           {:ok,
@@ -564,6 +565,15 @@ defmodule AniminaWeb.ProfileLive do
       Reaction.by_sender_and_receiver_id(user_id, current_user_id)
 
     reaction
+  end
+
+  defp user_states_not_visible_to_anonymous_users do
+    [
+      :under_investigation,
+      :banned,
+      :archived,
+      :hibernate
+    ]
   end
 
   defp user_states_to_be_auto_logged_out do

--- a/lib/animina_web/potential_partner.ex
+++ b/lib/animina_web/potential_partner.ex
@@ -46,6 +46,8 @@ defmodule AniminaWeb.PotentialPartner do
     |> partner_not_self_query(user)
     |> partner_not_under_investigation_query(user)
     |> partner_not_banned_query(user)
+    |> partner_not_archived_query(user)
+    |> partner_not_hibernate_query(user)
     |> partner_bookmarked_query(user, remove_bookmarked)
     |> Ash.Query.limit(limit)
     |> Accounts.read!()
@@ -64,6 +66,11 @@ defmodule AniminaWeb.PotentialPartner do
   defp partner_not_archived_query(query, _user) do
     query
     |> Ash.Query.filter(state: [not_eq: :archived])
+  end
+
+  defp partner_not_hibernate_query(query, _user) do
+    query
+    |> Ash.Query.filter(state: [not_eq: :hibernate])
   end
 
   defp partner_not_self_query(query, user) do

--- a/test/animina/accounts/user_test.exs
+++ b/test/animina/accounts/user_test.exs
@@ -69,5 +69,74 @@ defmodule Animina.Accounts.UserTest do
 
       assert Enum.any?(user_roles, fn user_role -> user_role.role.name == :user end)
     end
+
+    test "hibernate/1 returns a user with the state :hibernate" do
+      assert {:ok, user} =
+               BasicUser.create(%{
+                 email: "bob@example.com",
+                 username: "bob",
+                 name: "Bob",
+                 hashed_password: "zzzzzzzzzzz",
+                 birthday: "1950-01-01",
+                 height: 180,
+                 zip_code: "56068",
+                 gender: "male",
+                 mobile_phone: "0151-12345678",
+                 language: "de",
+                 legal_terms_accepted: true
+               })
+
+      assert user.state == :normal
+
+      {:ok, user} = User.hibernate(user)
+
+      assert user.state == :hibernate
+    end
+
+    test "ban/1 returns a user with the state :banned" do
+      assert {:ok, user} =
+               BasicUser.create(%{
+                 email: "bob@example.com",
+                 username: "bob",
+                 name: "Bob",
+                 hashed_password: "zzzzzzzzzzz",
+                 birthday: "1950-01-01",
+                 height: 180,
+                 zip_code: "56068",
+                 gender: "male",
+                 mobile_phone: "0151-12345678",
+                 language: "de",
+                 legal_terms_accepted: true
+               })
+
+      assert user.state == :normal
+
+      {:ok, user} = User.ban(user)
+
+      assert user.state == :banned
+    end
+
+    test "investigate/1 returns a user with the state :under_investigation" do
+      assert {:ok, user} =
+               BasicUser.create(%{
+                 email: "bob@example.com",
+                 username: "bob",
+                 name: "Bob",
+                 hashed_password: "zzzzzzzzzzz",
+                 birthday: "1950-01-01",
+                 height: 180,
+                 zip_code: "56068",
+                 gender: "male",
+                 mobile_phone: "0151-12345678",
+                 language: "de",
+                 legal_terms_accepted: true
+               })
+
+      assert user.state == :normal
+
+      {:ok, user} = User.investigate(user)
+
+      assert user.state == :under_investigation
+    end
   end
 end

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -236,6 +236,17 @@ defmodule AniminaWeb.ProfileTest do
       end
     end
 
+    test "If an account is hibernate , the profile returns a 404", %{
+      conn: conn,
+      public_user: public_user
+    } do
+      {:ok, user} = User.hibernate(public_user)
+
+      assert_raise Animina.Fallback, fn ->
+        get(conn, "/#{user.username}") |> response(404)
+      end
+    end
+
     test "If an account is under investigation , admins can view that profile", %{
       conn: conn,
       public_user: public_user,
@@ -259,6 +270,32 @@ defmodule AniminaWeb.ProfileTest do
 
       assert response(conn, 200)
     end
+
+
+    test "If an account is hibernate, admins can view that profile", %{
+      conn: conn,
+      public_user: public_user,
+      private_user: private_user
+    } do
+      {:ok, _user} = User.hibernate(public_user)
+
+      admin_role = create_admin_role()
+
+      create_admin_user_role(private_user.id, admin_role.id)
+
+      conn =
+        get(
+          conn
+          |> login_user(%{
+            "username_or_email" => private_user.username,
+            "password" => "MichaelTheEngineer"
+          }),
+          "/#{public_user.username}"
+        )
+
+      assert response(conn, 200)
+    end
+
 
     test "If an account is banned , admins can view that profile", %{
       conn: conn,

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -271,7 +271,6 @@ defmodule AniminaWeb.ProfileTest do
       assert response(conn, 200)
     end
 
-
     test "If an account is hibernate, admins can view that profile", %{
       conn: conn,
       public_user: public_user,
@@ -295,7 +294,6 @@ defmodule AniminaWeb.ProfileTest do
 
       assert response(conn, 200)
     end
-
 
     test "If an account is banned , admins can view that profile", %{
       conn: conn,

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -212,6 +212,19 @@ defmodule AniminaWeb.RootTest do
 
       assert error == "Account is archived, Kindly Contact Support"
     end
+
+    test "A user can login with their email and password if their account is hibernated", %{conn: conn} do
+      {:ok, user} = User.create(@valid_create_user_attrs)
+
+        {:ok, user} = User.hibernate(user)
+
+      {:ok, _index_live, html} =
+        conn
+        |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
+        |> live(~p"/my/potential-partner/")
+
+      assert html =~ "Criteria for your new partner"
+    end
   end
 
   defp sign_in_user(conn, attributes) do

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -213,10 +213,12 @@ defmodule AniminaWeb.RootTest do
       assert error == "Account is archived, Kindly Contact Support"
     end
 
-    test "A user can login with their email and password if their account is hibernated", %{conn: conn} do
+    test "A user can login with their email and password if their account is hibernated", %{
+      conn: conn
+    } do
       {:ok, user} = User.create(@valid_create_user_attrs)
 
-        {:ok, user} = User.hibernate(user)
+      {:ok, user} = User.hibernate(user)
 
       {:ok, _index_live, html} =
         conn


### PR DESCRIPTION
Tasks are the following

For a profile that is hibernated ,

- [x] They can log in
- [x] People cannot view their profile
- [x] Admins Can view their profile
- [x] We do not use them in the potential partners query
- [x] Added unit and integration tests