### PR TITLE
Fix username not in nil bug , closes #677

### DIFF
--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -16,8 +16,8 @@ defmodule Animina.Checks.ReadProfileCheck do
     check_if_user_can_view_profile(actor, params, params.query.arguments)
   end
 
-  defp check_if_user_can_view_profile(nil, params, %{username: _username}) do
-   false
+  defp check_if_user_can_view_profile(nil, _params, %{username: _username}) do
+    false
   end
 
   defp check_if_user_can_view_profile(actor, params, %{username: _username}) do

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -23,7 +23,7 @@ defmodule Animina.Checks.ReadProfileCheck do
   defp check_if_user_can_view_profile(actor, params, %{username: _username}) do
     case User.by_username(params.query.arguments.username) do
       {:ok, profile} ->
-        if actor.username == profile.username || profile.is_private == false do
+        if actor && (actor.username == profile.username || profile.is_private == false) do
           user_can_view_profile(
             admin_user?(actor),
             profile.state

--- a/lib/animina/checks/read_profile_check.ex
+++ b/lib/animina/checks/read_profile_check.ex
@@ -16,6 +16,10 @@ defmodule Animina.Checks.ReadProfileCheck do
     check_if_user_can_view_profile(actor, params, params.query.arguments)
   end
 
+  defp check_if_user_can_view_profile(nil, params, %{username: _username}) do
+   false
+  end
+
   defp check_if_user_can_view_profile(actor, params, %{username: _username}) do
     case User.by_username(params.query.arguments.username) do
       {:ok, profile} ->


### PR DESCRIPTION
- @wintermeyer  , this fix wil ensure that if by any chance the session token was cached  but the current_user is nil , we check for the profile without an actor and we take you as an anonymous user. Kindly confirm if this now works.
The tests for this were already there but we had no way to check if session is cached.
The extra check I have now on the live view and context should ensure we are good