### PR TITLE
Create Change Profile visibility page , closes #681

### DIFF
--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -178,8 +178,17 @@ defmodule Animina.Accounts.User do
       transition(:investigate, from: [:normal, :validated], to: :under_investigation)
       transition(:ban, from: [:normal, :validated, :under_investigation], to: :banned)
       transition(:incognito, from: [:normal, :validated, :under_investigation], to: :incognito)
-      transition(:hibernate, from: [:normal, :validated, :under_investigation], to: :hibernate)
-      transition(:archive, from: [:normal, :validated, :under_investigation], to: :archived)
+
+      transition(:hibernate,
+        from: [:normal, :validated, :under_investigation, :archived],
+        to: :hibernate
+      )
+
+      transition(:archive,
+        from: [:normal, :validated, :under_investigation, :hibernate],
+        to: :archived
+      )
+
       transition(:reactivate, from: [:incognito, :hibernate], to: :normal)
       transition(:unban, from: [:banned], to: :normal)
       transition(:recover, from: [:archived], to: :normal)

--- a/lib/animina_web/components/profile/profile_components.ex
+++ b/lib/animina_web/components/profile/profile_components.ex
@@ -3,6 +3,7 @@ defmodule AniminaWeb.ProfileComponents do
   Provides Profile UI components.
   """
   use Phoenix.Component
+  import AniminaWeb.Gettext
 
   def profile_details(assigns) do
     ~H"""
@@ -438,6 +439,101 @@ defmodule AniminaWeb.ProfileComponents do
         current_user_height_for_figure={@current_user_height_for_figure}
         profile_user={@user}
       />
+    </div>
+    """
+  end
+
+  def user_state_cards(assigns) do
+    ~H"""
+    <div class="flex flex-col gap-4">
+      <%= for state <- user_states_to_display_to_profile() do %>
+        <.user_state_card
+          state={@current_user.state}
+          name={state["name"]}
+          similar_value={state["similar_value"]}
+          value={state["value"]}
+          description={state["description"]}
+          action={state["action"]}
+        />
+      <% end %>
+    </div>
+    """
+  end
+
+  defp user_state_card(assigns) do
+    ~H"""
+    <div
+      phx-click={
+        if @state != @value || @state != @similar_value do
+          "change_user_state"
+        end
+      }
+      data-confirm={"Are you sure you want to change from #{@value} to #{@state}?"}
+      phx-value-state={@state}
+      phx-value-action={@action}
+      class="flex hover:bg-blue-100 group cursor-pointer hover:text-blue-600 p-3 transition-all ease-in-out duration-500 flex-col gap-1 "
+    >
+      <div class="w-[100%] flex justify-between items-start">
+        <div class="flex  w-[70%] flex-col gap-1">
+          <p class="text-xl group-hover:text-gray-900 transition-all ease-in-out duration-500  text-white">
+            <%= @name %>
+          </p>
+          <p class="text-gray-400">
+            <%= @description %>
+          </p>
+        </div>
+
+        <.active_mark :if={@state == @value || @state == @similar_value} />
+      </div>
+
+      <p class="h-[1px] w-[100%] bg-white" />
+    </div>
+    """
+  end
+
+  defp user_states_to_display_to_profile do
+    [
+      %{
+        "name" => gettext("Normal"),
+        "value" => :normal,
+        "similar_value" => :validated,
+        "action" => "normalize",
+        "description" =>
+          gettext("The user is actively using the account, engaging with posts and other users.")
+      },
+      %{
+        "name" => gettext("Hibernate"),
+        "value" => :hibernate,
+        "similar_value" => :hibernate,
+        "action" => "hibernate",
+        "description" =>
+          gettext(
+            "The user is temporarily inactive but retains their account and data for future use."
+          )
+      },
+      %{
+        "name" => gettext("Archived"),
+        "value" => :archived,
+        "action" => "archive",
+        "similar_value" => :archived,
+        "description" =>
+          gettext("The account is permanently deleted and all data is no longer accessible.")
+      },
+      %{
+        "name" => gettext("Incognito"),
+        "value" => :incognito,
+        "action" => "incognito",
+        "similar_value" => :incognito,
+        "description" =>
+          gettext("The user can browse and read posts anonymously, without being seen by others.")
+      }
+    ]
+  end
+
+  defp active_mark(assigns) do
+    ~H"""
+    <div class="text-green-500  flex items-center gap-1">
+      Active
     </div>
     """
   end

--- a/lib/animina_web/components/profile/profile_components.ex
+++ b/lib/animina_web/components/profile/profile_components.ex
@@ -471,22 +471,23 @@ defmodule AniminaWeb.ProfileComponents do
       data-confirm={"Are you sure you want to change from #{@value} to #{@state}?"}
       phx-value-state={@state}
       phx-value-action={@action}
+      id={"user-state-#{@value}"}
       class="flex hover:bg-blue-100 group cursor-pointer hover:text-blue-600 p-3 transition-all ease-in-out duration-500 flex-col gap-1 "
     >
       <div class="w-[100%] flex justify-between items-start">
-        <div class="flex  w-[70%] flex-col gap-1">
-          <p class="text-xl group-hover:text-gray-900 transition-all ease-in-out duration-500  text-white">
+        <div class="flex   flex-col gap-1">
+          <p class="text-xl group-hover:text-gray-900 transition-all ease-in-out duration-500 text-black  dark:text-white">
             <%= @name %>
           </p>
-          <p class="text-gray-400">
+          <p class="group-hover:text-blue-600 text-gray-400">
             <%= @description %>
           </p>
         </div>
 
-        <.active_mark :if={@state == @value || @state == @similar_value} />
+        <.active_mark :if={@state == @value || @state == @similar_value} value={@value} />
       </div>
 
-      <p class="h-[1px] w-[100%] bg-white" />
+      <p class="h-[1px] w-[100%] bg-black dark:bg-white" />
     </div>
     """
   end
@@ -532,8 +533,11 @@ defmodule AniminaWeb.ProfileComponents do
 
   defp active_mark(assigns) do
     ~H"""
-    <div class="text-green-500  flex items-center gap-1">
-      Active
+    <div
+      class="text-green-500 group-hover:text-blue-600  flex items-center gap-1"
+      id={"active-mark-#{@value}"}
+    >
+      <%= gettext("Active") %>
     </div>
     """
   end

--- a/lib/animina_web/components/top_navigation_components.ex
+++ b/lib/animina_web/components/top_navigation_components.ex
@@ -176,6 +176,11 @@ defmodule AniminaWeb.TopNavigationCompontents do
           <.link class="px-2" navigate="/my/potential-partner">
             <%= gettext("Edit Potential Partner Preferences") %>
           </.link>
+          <.link class="px-2" navigate="/my/profile/visibility">
+            <div class="flex gap-2 items-center">
+              <%= gettext("Change Visibility") %>
+            </div>
+          </.link>
           <p class=" h-[1px] bg-gray-100 my-1 w-[100%]"></p>
           <.link class="px-2" navigate="/auth/user/sign-out">
             <%= gettext("Sign Out") %>

--- a/lib/animina_web/live/profile_visibility.ex
+++ b/lib/animina_web/live/profile_visibility.ex
@@ -1,0 +1,117 @@
+defmodule AniminaWeb.ProfileVisibilityLive do
+  @moduledoc """
+  User Profile Liveview
+  """
+
+  use AniminaWeb, :live_view
+  alias Animina.Accounts
+  alias Animina.Accounts.BasicUser
+  alias Animina.Accounts.Points
+  alias Animina.Accounts.User
+  alias Animina.GenServers.ProfileViewCredits
+  alias Phoenix.PubSub
+
+  @impl true
+  def mount(_params, %{"language" => language, "user" => _}, socket) do
+    socket =
+      socket
+      |> assign(language: language)
+
+    current_user =
+      socket.assigns.current_user
+
+    subscribe(socket, current_user)
+
+    {
+      :ok,
+      socket |> assign(active_tab: :profile_visibility)
+    }
+  end
+
+  defp subscribe(socket, _) do
+    if connected?(socket) do
+      PubSub.subscribe(Animina.PubSub, "credits")
+      PubSub.subscribe(Animina.PubSub, "messages")
+
+      PubSub.subscribe(
+        Animina.PubSub,
+        "#{socket.assigns.current_user.id}"
+      )
+    end
+  end
+
+  @impl true
+  def handle_info({:display_updated_credits, credits}, socket) do
+    current_user_credit_points =
+      ProfileViewCredits.get_updated_credit_for_current_user(socket.assigns.current_user, credits)
+      |> Points.humanized_points()
+
+    {:noreply,
+     socket
+     |> assign(current_user_credit_points: current_user_credit_points)}
+  end
+
+  def handle_info({:user, current_user}, socket) do
+    {:noreply, socket |> assign(current_user: current_user)}
+  end
+
+  def handle_info({:credit_updated, _updated_credit}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_info({:new_message, message}, socket) do
+    unread_messages = socket.assigns.unread_messages ++ [message]
+
+    {:noreply,
+     socket
+     |> assign(unread_messages: unread_messages)
+     |> assign(number_of_unread_messages: Enum.count(unread_messages))}
+  end
+
+  def handle_event("change_user_state", %{"state" => _state, "action" => action}, socket) do
+    case change_user_state(action, socket.assigns.current_user) do
+      {:ok, user} ->
+        {:noreply,
+         socket
+         |> assign(current_user: user)
+         |> put_flash(:info, gettext("Profile visibility changed successfully."))}
+
+      {:error, _} ->
+        {:noreply, socket |> put_flash(:error, gettext("Profile visibility change failed."))}
+    end
+  end
+
+  def change_user_state("normalize", user) do
+    User.normalize(user)
+  end
+
+  def change_user_state("archive", user) do
+    User.archive(user)
+  end
+
+  def change_user_state("hibernate", user) do
+    User.hibernate(user)
+  end
+
+  def change_user_state("incognito", user) do
+    User.incognito(user)
+  end
+
+  def change_user_state(_, user) do
+    User.normalize(user)
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="px-5 flex flex-col gap-2 pb-8">
+      <p class="text-xl text-white dark:text-white"><%= gettext("Change Profile Visibility") %></p>
+      <p class="text-sm text-gray-500">
+        <%= gettext("Select And Change the visibility of your profile") %>
+      </p>
+
+      <.user_state_cards current_user={@current_user} />
+    </div>
+    """
+  end
+end

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -43,6 +43,7 @@ defmodule AniminaWeb.Router do
       live "/my/messages/:profile", ChatLive, :index
       live "/my", DashboardLive, :index
       live "/my/dashboard", DashboardLive, :index
+      live "/my/profile/visibility", ProfileVisibilityLive, :index
       live "/:current_user/messages/:profile", ChatLive, :index
     end
 

--- a/test/animina_web/live/profile_visibility_test.exs
+++ b/test/animina_web/live/profile_visibility_test.exs
@@ -1,0 +1,269 @@
+defmodule AniminaWeb.ProfileVisibilityTest do
+  use AniminaWeb.ConnCase
+  import Phoenix.LiveViewTest
+  alias Animina.Accounts.User
+
+  describe "Tests the Profile Visibility Live" do
+    setup do
+      user = create_user()
+
+      [
+        user: user
+      ]
+    end
+
+    test "When we Visit /my/profile/visibility we can change a page to change profile visibility",
+         %{
+           conn: conn,
+           user: user
+         } do
+      {:ok, _index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert html =~ "Change Profile Visibility"
+
+      # we check to ensure we can see the 4 states a user can change to
+      assert html =~ "Normal"
+      assert html =~ "Hibernate"
+      assert html =~ "Archived"
+      assert html =~ "Incognito"
+    end
+
+    test "The state of the current user will have a corresponding active text next to it",
+         %{
+           conn: conn,
+           user: user
+         } do
+      {:ok, index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert html =~ "Change Profile Visibility"
+
+      assert user.state == :normal
+
+      assert has_element?(index_live, "#active-mark-#{user.state}")
+    end
+
+    test "You can click on the Incognito div to change the profile visibility to incognito",
+         %{
+           conn: conn,
+           user: user
+         } do
+      {:ok, index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert html =~ "Change Profile Visibility"
+
+      index_live
+      |> element("#user-state-incognito")
+      |> render_click()
+
+      user = User.by_id!(user.id)
+
+      {:ok, index_live, _html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert has_element?(index_live, "#active-mark-incognito")
+      refute has_element?(index_live, "#active-mark-normal")
+
+      assert user.state == :incognito
+      refute user.state == :normal
+    end
+
+    test "You can click on the Hibernate div to change the profile visibility to hibernate",
+         %{
+           conn: conn,
+           user: user
+         } do
+      {:ok, index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert html =~ "Change Profile Visibility"
+
+      index_live
+      |> element("#user-state-hibernate")
+      |> render_click()
+
+      user = User.by_id!(user.id)
+
+      {:ok, index_live, _html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert has_element?(index_live, "#active-mark-hibernate")
+      refute has_element?(index_live, "#active-mark-normal")
+
+      assert user.state == :hibernate
+      refute user.state == :normal
+    end
+
+    test "You can click on the Archive to change the profile visibility to archived, you will be auto logged out",
+         %{
+           conn: conn,
+           user: user
+         } do
+      {:ok, index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert html =~ "Change Profile Visibility"
+
+      index_live
+      |> element("#user-state-archived")
+      |> render_click()
+
+      user = User.by_id!(user.id)
+
+      {:error, {:redirect, %{to: _, flash: %{"error" => error}}}} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert error == "Account is archived, Kindly Contact Support"
+    end
+
+    test "If a user is incognito , they can go back to the normal state by clicking the Normal Div",
+         %{
+           conn: conn,
+           user: user
+         } do
+      {:ok, user} = User.incognito(user)
+
+      {:ok, index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert html =~ "Change Profile Visibility"
+
+      assert user.state == :incognito
+
+      index_live
+      |> element("#user-state-normal")
+      |> render_click()
+
+      user = User.by_id!(user.id)
+
+      {:ok, index_live, _html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert has_element?(index_live, "#active-mark-normal")
+      refute has_element?(index_live, "#active-mark-incognito")
+
+      assert user.state == :normal
+      refute user.state == :incognito
+    end
+
+    test "If a user is hibernate , they can go back to the normal state by clicking the Normal Div",
+         %{
+           conn: conn,
+           user: user
+         } do
+      {:ok, user} = User.hibernate(user)
+
+      {:ok, index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert html =~ "Change Profile Visibility"
+
+      assert user.state == :hibernate
+
+      index_live
+      |> element("#user-state-normal")
+      |> render_click()
+
+      user = User.by_id!(user.id)
+
+      {:ok, index_live, _html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/my/profile/visibility")
+
+      assert has_element?(index_live, "#active-mark-normal")
+      refute has_element?(index_live, "#active-mark-hibernate")
+
+      assert user.state == :normal
+      refute user.state == :hibernate
+    end
+  end
+
+  defp create_user do
+    {:ok, user} =
+      User.create(%{
+        email: "adam@example.com",
+        username: "adam",
+        name: "Adam Newuser",
+        hashed_password: Bcrypt.hash_pwd_salt("MichaelTheEngineer"),
+        birthday: "1950-01-01",
+        height: 180,
+        zip_code: "56068",
+        gender: "male",
+        mobile_phone: "0151-12345678",
+        language: "en",
+        legal_terms_accepted: true
+      })
+
+    user
+  end
+
+  defp login_user(conn, attributes) do
+    {:ok, lv, _html} = live(conn, ~p"/sign-in/")
+
+    form =
+      form(lv, "#basic_user_sign_in_form", user: attributes)
+
+    submit_form(form, conn)
+  end
+end


### PR DESCRIPTION
- I added a page on /my/profille/visibilty` where the user can change their visibility.
- To access this page , they do so by clicking the link `Change My Visibility` on the dropdown
- I added unit and integration tests for this feature
- For a validated account , we show it as a normal one , so we have the following states shown ,  `Normal , Archived , Hibernate , Incognito`
- The active user state has a `Active` link next to it in Green


https://github.com/animina-dating/animina/assets/86654131/d9f0cebd-f652-4f72-90ce-0e1d3607799f

![Screenshot 2024-06-21 at 07 24 37](https://github.com/animina-dating/animina/assets/86654131/3b195a2e-5e87-4982-8ff3-edee687eb394)


![Screenshot 2024-06-21 at 07 25 56](https://github.com/animina-dating/animina/assets/86654131/8066ff5c-aa94-4736-8715-cbb467b0277f)

![Screenshot 2024-06-21 at 07 26 37](https://github.com/animina-dating/animina/assets/86654131/928f2bfc-d4ec-4712-8dcc-43be2aa56984)
![Screenshot 2024-06-21 at 07 26 45](https://github.com/animina-dating/animina/assets/86654131/1bc0281f-0040-4a93-84d2-3e1cd0ef1062)

