### PR TITLE
Fixes key :active_tab not found in: %{ user: #Animina.Accounts.User , closes #684

### DIFF
--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -28,6 +28,7 @@ defmodule AniminaWeb.ProfileLive do
           {:ok,
            socket
            |> assign(user: user)
+           |> assign(active_tab: "")
            |> assign(current_user_credit_points: 0)
            |> assign(intersecting_green_flags_count: 0)
            |> assign(intersecting_red_flags_count: 0)


### PR DESCRIPTION
- Fixed this bug by adding :active_tab key