### PR TITLE
Add Liveview Tests for the Chat Live , closes #698

### DIFF
--- a/lib/animina_web/components/profile/profile_components.ex
+++ b/lib/animina_web/components/profile/profile_components.ex
@@ -668,7 +668,7 @@ defmodule AniminaWeb.ProfileComponents do
     <div>
       <%= if @current_user && @display_chat_icon do %>
         <div :if={@current_user.id != @user.id} class="text-gray-300 cursor-pointer dark:text-white">
-          <.link navigate={"/my/messages/#{@user.username}"}>
+          <.link navigate={"/#{@current_user.username}/messages/#{@user.username}"} id="chat_button">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"

--- a/lib/animina_web/components/top_navigation_components.ex
+++ b/lib/animina_web/components/top_navigation_components.ex
@@ -249,7 +249,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
       <div class="flex w-[100%]  p-4 flex-col gap-2">
         <p class=" dark:text-white"><%= gettext("Could Interest You") %></p>
 
-        <div class="flex w-[100%] h-[50vh] overflow-y-scroll flex-col gap-2">
+        <div class={"flex w-[100%] #{if @current_user do " h-[50vh] overflow-y-scroll" end } flex-col gap-2"}>
           <.random_interests
             interests={six_random_public_users(@current_user)}
             current_user={@current_user}

--- a/lib/animina_web/live/chat_live.ex
+++ b/lib/animina_web/live/chat_live.ex
@@ -436,6 +436,7 @@ defmodule AniminaWeb.ChatLive do
           for={@form}
           phx-change="validate"
           phx-submit="submit"
+          id="message_form"
           class="w-[100%] flex justify-between items-end"
         >
           <div phx-feedback-for={f[:content].name} class="md:w-[93%] w-[90%]">

--- a/test/animina_web/live/chat_test.exs
+++ b/test/animina_web/live/chat_test.exs
@@ -2,8 +2,8 @@ defmodule AniminaWeb.ChatTest do
   use AniminaWeb.ConnCase
   import Phoenix.LiveViewTest
   alias Animina.Accounts.Credit
-  alias Animina.Accounts.User
   alias Animina.Accounts.Message
+  alias Animina.Accounts.User
 
   describe "Tests the Chat Live" do
     setup do

--- a/test/animina_web/live/chat_test.exs
+++ b/test/animina_web/live/chat_test.exs
@@ -1,0 +1,104 @@
+defmodule AniminaWeb.ChatTest do
+  use AniminaWeb.ConnCase
+  import Phoenix.LiveViewTest
+  alias Animina.Accounts.Bookmark
+  alias Animina.Accounts.Credit
+  alias Animina.Accounts.Role
+  alias Animina.Accounts.User
+  alias Animina.Accounts.UserRole
+  alias Animina.Accounts.VisitLogEntry
+  alias Animina.Narratives.Headline
+  alias Animina.Narratives.Story
+
+  describe "Tests the Chat Live" do
+    setup do
+      public_user = create_public_user()
+
+      private_user = create_private_user()
+
+      Credit.create!(%{
+        user_id: private_user.id,
+        points: 100,
+        subject: "Registration bonus"
+      })
+
+      Credit.create!(%{
+        user_id: public_user.id,
+        points: 100,
+        subject: "Registration bonus"
+      })
+
+      [
+        public_user: public_user,
+        private_user: private_user
+      ]
+    end
+
+    test "You see a user's Mini Profile if you visit their chat live", %{
+      conn: conn,
+      public_user: public_user,
+      private_user: private_user
+    } do
+      # we visit the message box for public user and private user
+
+      {:ok, _index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => public_user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/#{public_user.username}/messages/#{private_user.username}")
+
+      assert html =~ private_user.name
+      assert html =~ "#{private_user.height}"
+    end
+  end
+
+  defp create_public_user do
+    {:ok, user} =
+      User.create(%{
+        email: "adam@example.com",
+        username: "adam",
+        name: "Adam Newuser",
+        hashed_password: Bcrypt.hash_pwd_salt("MichaelTheEngineer"),
+        birthday: "1950-01-01",
+        height: 180,
+        zip_code: "56068",
+        gender: "male",
+        mobile_phone: "0151-12345678",
+        language: "en",
+        legal_terms_accepted: true
+      })
+
+    user
+  end
+
+  defp create_private_user do
+    {:ok, user} =
+      User.create(%{
+        email: "private@example.com",
+        username: "private",
+        name: "Private",
+        hashed_password: Bcrypt.hash_pwd_salt("MichaelTheEngineer"),
+        birthday: "1950-01-01",
+        height: 180,
+        zip_code: "56068",
+        gender: "male",
+        mobile_phone: "0151-22345678",
+        language: "en",
+        is_private: true,
+        legal_terms_accepted: true
+      })
+
+    user
+  end
+
+  defp login_user(conn, attributes) do
+    {:ok, lv, _html} = live(conn, ~p"/sign-in/")
+
+    form =
+      form(lv, "#basic_user_sign_in_form", user: attributes)
+
+    submit_form(form, conn)
+  end
+end


### PR DESCRIPTION
- Added Liveview tests for the chat live for the following


- [x] You are redirected to the chat page of a profile by clicking the chat icon on top of a profile
- [x] if you visit /my/messages/profile you will be redirected to /current_user/messages/profile
- [x] You see a user's Mini Profile if you visit their chat live
- [x] You can send a message through the message box
- [x] You can view messages received in the chat box
- [x] Once You view a chat page , all messages that had previously not been read will be marked as read