### PR TITLE
Display the version number in the footer of each page , closes #793

### DIFF
--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -156,7 +156,7 @@ defmodule Animina.Accounts.Photo do
 
   changes do
     change after_transaction(fn
-             changeset, {:ok, result} , _context ->
+             changeset, {:ok, result}, _context ->
                {:ok, result}
 
              changeset, {:error, error} ->

--- a/lib/animina_web/components/animina_components.ex
+++ b/lib/animina_web/components/animina_components.ex
@@ -302,9 +302,15 @@ defmodule AniminaWeb.AniminaComponents do
       <div class="xl:grid xl:grid-cols-3 xl:gap-8">
         <div class="space-y-8">
           <p class="text-sm leading-6 text-gray-600 dark:text-gray-400">
-            <span class="text-sm font-semibold leading-6 text-gray-900 dark:text-white">Animina</span>
+            <span class="text-sm font-semibold leading-6 text-gray-900 dark:text-white">
+              Animina
+              <span>
+                v<%= Application.spec(:animina, :vsn) %>
+              </span>
+            </span>
             <br />Fair and common sense online-dating.
           </p>
+
           <p class="text-sm leading-6 text-gray-600 dark:text-gray-400">
             Founded by <a href="https://www.wintermeyer.de">Stefan Wintermeyer</a>.
           </p>


### PR DESCRIPTION
We now have in the footer

![Screenshot 2024-07-30 at 08 46 48](https://github.com/user-attachments/assets/4e8dd9be-7da9-4d04-b6fa-9232688ba1ed)
