### PR TITLE
Ensure Email Validation Emails are sent in the language of the user , closes #818

### DIFF
--- a/lib/animina/user_email.ex
+++ b/lib/animina/user_email.ex
@@ -4,18 +4,23 @@ defmodule Animina.UserEmail do
   """
 
   import Swoosh.Email
+  import AniminaWeb.Gettext
   alias Animina.Mailer
   use AshAuthentication.Sender
 
   def send(user, confirm, _opts) do
+    subject = gettext("Confirm your email address")
+    text_body = gettext("Hi!
+         Someone has tried to register a new account at \nAnimina\nhttps://animina.de.
+         If it was you, then please click the link below to confirm your identity.  If you did not initiate this request then please ignore this email.
+         \nClick here to confirm your account ")
+
     send_email(
       user.name,
       Ash.CiString.value(user.email),
-      "Confirm your email address",
-      "Hi!
-         Someone has tried to register a new account at \nAnimina\nhttps://animina.de.
-         If it was you, then please click the link below to confirm your identity.  If you did not initiate this request then please ignore this email.
-         \nClick here to confirm your account \n#{"https://animina.de/auth/user/confirm_new_user?#{URI.encode_query(confirm: confirm)}"}"
+      subject,
+      text_body <>
+        "\n#{"https://animina.de/auth/user/confirm_new_user?#{URI.encode_query(confirm: confirm)}"}"
     )
   end
 


### PR DESCRIPTION
- Added Gettext to the Registration Emails being sent out .