### PR TITLE
Made confirmation link to expire a year later , closes #815

### DIFF
--- a/lib/animina/accounts/resources/token.ex
+++ b/lib/animina/accounts/resources/token.ex
@@ -11,7 +11,6 @@ defmodule Animina.Accounts.Token do
     defaults [:read, :destroy]
   end
 
-
   code_interface do
     domain Animina.Accounts
     define :destroy

--- a/lib/animina/accounts/resources/token.ex
+++ b/lib/animina/accounts/resources/token.ex
@@ -11,6 +11,7 @@ defmodule Animina.Accounts.Token do
     defaults [:read, :destroy]
   end
 
+
   code_interface do
     domain Animina.Accounts
     define :destroy

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -519,6 +519,7 @@ defmodule Animina.Accounts.User do
       confirmation :confirm_new_user do
         monitor_fields [:email]
         sender Animina.UserEmail
+        token_lifetime {365, :days}
       end
     end
 


### PR DESCRIPTION
- Now the token for confirming your account expires after a year , @wintermeyer  kindly confirm if this is a long enough expiry , as you can see , this is the database record for that token
![Screenshot 2024-08-07 at 11 26 15](https://github.com/user-attachments/assets/7d60cd99-07da-4413-ab20-a5edca0fa754)
