### PR TITLE
Waitlist interface , closes #838

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ If you want to for example hibernate a user with the username 'wintermeyer' you 
 `{:ok, user} = Animina.Accounts.User.get_by_username("wintermeyer") `
 `Animina.Accounts.User.hibernate(%{user_id: user.id})`
 
+
+- To remove a user from a waitlist we use `User.give_user_in_waitlist_access` .
+An example of how to give a user in the waitlist access via CLI is 
+`{:ok, user} = Animina.Accounts.User.get_by_username("wintermeyer") `
+`Animina.Accounts.User.give_user_in_waitlist_access(user)`
+
+
 ### User Roles
 
 - We have 2 roles `user` and `admin` .

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If you want to for example hibernate a user with the username 'wintermeyer' you 
 
 
 - To remove a user from a waitlist we use `User.give_user_in_waitlist_access` .
+After removing a user from the waitlist, the user will get an email notification that they can now access the platform.
 An example of how to give a user in the waitlist access via CLI is 
 `{:ok, user} = Animina.Accounts.User.get_by_username("wintermeyer") `
 `Animina.Accounts.User.give_user_in_waitlist_access(user)`

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -298,6 +298,11 @@ defmodule Animina.Accounts.User do
       require_atomic? false
     end
 
+    update :give_user_in_waitlist_access do
+      change set_attribute(:is_in_waitlist, false)
+      require_atomic? false
+    end
+
     read :custom_sign_in do
       argument :username_or_email, :string, allow_nil?: false
       argument :password, :string, allow_nil?: false, sensitive?: true
@@ -330,6 +335,10 @@ defmodule Animina.Accounts.User do
 
     read :users_registered_within_the_hour do
       filter expr(created_at >= ^DateTime.add(DateTime.utc_now(), -1, :hour))
+    end
+
+    read :users_in_waitlist do
+      filter expr(is_in_waitlist == ^true)
     end
 
     update :validate do
@@ -439,7 +448,9 @@ defmodule Animina.Accounts.User do
     define :custom_sign_in, get?: true
     define :female_public_users_who_created_an_account_in_the_last_60_days
     define :male_public_users_who_created_an_account_in_the_last_60_days
+    define :users_in_waitlist
     define :investigate
+    define :give_user_in_waitlist_access
     define :ban
     define :archive
     define :hibernate

--- a/lib/animina_web.ex
+++ b/lib/animina_web.ex
@@ -97,6 +97,7 @@ defmodule AniminaWeb do
       import AniminaWeb.Gettext
       import AniminaWeb.PostsComponents
       import AniminaWeb.ReportComponents
+      import AniminaWeb.WaitlistComponents
 
       # https://elixirforum.com/t/form-for-not-working-in-phoenix-1-7/52013
 

--- a/lib/animina_web/components/top_navigation_components.ex
+++ b/lib/animina_web/components/top_navigation_components.ex
@@ -230,6 +230,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
 
         <.bookmarks_nav_item current_user={@current_user} active_tab={@active_tab} />
         <.reports_nav_item current_user={@current_user} active_tab={@active_tab} />
+        <.waitlist_nav_item current_user={@current_user} active_tab={@active_tab} />
         <.user_profile_item
           current_user={@current_user}
           active_tab={@active_tab}
@@ -257,6 +258,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
         <.home_nav_item current_user={@current_user} active_tab={@active_tab} />
         <.bookmarks_nav_item current_user={@current_user} active_tab={@active_tab} />
         <.reports_nav_item current_user={@current_user} active_tab={@active_tab} />
+        <.waitlist_nav_item current_user={@current_user} active_tab={@active_tab} />
         <.user_profile_item
           current_user={@current_user}
           active_tab={@active_tab}
@@ -485,6 +487,26 @@ defmodule AniminaWeb.TopNavigationCompontents do
     </svg>
 
       <span><%= gettext("Reports") %></span>
+      </.link>
+
+      </.top_navigation_entry>
+    <% end %>
+    """
+  end
+
+  def waitlist_nav_item(assigns) do
+    ~H"""
+    <%= if @current_user && admin_user?(@current_user)  do %>
+      <.top_navigation_entry phx-no-format is_active={@active_tab == :waitlist}>
+    <.link navigate={"/admin/waitlist"} class="flex flex-row items-center gap-2" >
+
+
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 12h16.5m-16.5 3.75h16.5M3.75 19.5h16.5M5.625 4.5h12.75a1.875 1.875 0 0 1 0 3.75H5.625a1.875 1.875 0 0 1 0-3.75Z" />
+    </svg>
+
+
+      <span><%= gettext("Waitlist") %></span>
       </.link>
 
       </.top_navigation_entry>

--- a/lib/animina_web/components/waitlist_components.ex
+++ b/lib/animina_web/components/waitlist_components.ex
@@ -1,0 +1,53 @@
+defmodule AniminaWeb.WaitlistComponents do
+  @moduledoc """
+  Provides Waitlist UI components.
+  """
+  use Phoenix.Component
+  import AniminaWeb.Gettext
+  import AniminaWeb.CoreComponents
+  use PhoenixHTMLHelpers
+
+  def waitlist_users_table(assigns) do
+    ~H"""
+    <div>
+      <p class="my-3 dark:text-white text-black text-xl">
+        <%= gettext("The following users are on the waitlist") %>
+      </p>
+
+      <div class="overflow-hidden border-b dark:border-gray-700 border-gray-200 rounded shadow">
+        <table class="min-w-full text-left bg-white table-auto ">
+          <thead>
+            <tr class="text-white dark:bg-gray-700 bg-gray-800">
+              <th class="px-4 py-3"><%= gettext("Name") %></th>
+              <th class="px-4 py-3"><%= gettext("Profile") %></th>
+              <th class="px-4 py-3"><%= gettext("Email") %></th>
+              <th class="px-4 py-3"><%= gettext("Action") %></th>
+            </tr>
+          </thead>
+          <tbody class="">
+            <%= for user <- @users do %>
+              <tr>
+                <td class="px-4 py-3"><%= user.name %></td>
+                <td class="px-4 text-blue-500 py-3">
+                  <a href={"/#{user.username}"}><%= user.username %></a>
+                </td>
+                <td class="px-4 py-3"><%= user.email %></td>
+                <td class="px-4 py-3">
+                  <button
+                    phx-value-id={user.id}
+                    phx-click="give_user_in_waitlist_access"
+                    data-confirm="Are You Sure?"
+                    class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+                  >
+                    <%= gettext("Give Access") %>
+                  </button>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/animina_web/components/waitlist_components.ex
+++ b/lib/animina_web/components/waitlist_components.ex
@@ -4,7 +4,6 @@ defmodule AniminaWeb.WaitlistComponents do
   """
   use Phoenix.Component
   import AniminaWeb.Gettext
-  import AniminaWeb.CoreComponents
   use PhoenixHTMLHelpers
 
   def waitlist_users_table(assigns) do

--- a/lib/animina_web/live/too_successful_live.ex
+++ b/lib/animina_web/live/too_successful_live.ex
@@ -21,9 +21,10 @@ defmodule AniminaWeb.TooSuccessFulLive do
           ) %>
           <span>
             <a href="mailto:stefan@wintermeyer.de" class="text-blue-500 underline">
-              stefan@wintermeyer.de 
+              stefan@wintermeyer.de
             </a>
-          </span> <%= gettext("The buck stops in my inbox.") %>
+          </span>
+          <%= gettext("The buck stops in my inbox.") %>
         </p>
       </div>
     </div>

--- a/lib/animina_web/live/waitlist_live.ex
+++ b/lib/animina_web/live/waitlist_live.ex
@@ -1,0 +1,102 @@
+defmodule AniminaWeb.WaitlistLive do
+  use AniminaWeb, :live_view
+
+  alias Animina.Accounts.Points
+
+  alias Animina.Accounts.User
+
+  alias Phoenix.PubSub
+
+  alias Animina.GenServers.ProfileViewCredits
+  @impl true
+  def mount(_params, %{"language" => language} = _session, socket) do
+    if connected?(socket) do
+      PubSub.subscribe(Animina.PubSub, "messages")
+
+      PubSub.subscribe(
+        Animina.PubSub,
+        "#{socket.assigns.current_user.id}"
+      )
+
+      Phoenix.PubSub.subscribe(
+        Animina.PubSub,
+        "user_flag:created:#{socket.assigns.current_user.id}"
+      )
+    end
+
+    socket =
+      socket
+      |> assign(active_tab: :waitlist)
+      |> assign(:language, language)
+      |> assign(:page_title, gettext("Waitlist"))
+
+    {:ok, socket}
+  end
+
+  def handle_params(_, _, socket) do
+    users_in_waitlist = User.users_in_waitlist!()
+    {:noreply, socket |> assign(users_in_waitlist: users_in_waitlist)}
+  end
+
+  def handle_event("give_user_in_waitlist_access", %{"id" => id}, socket) do
+    user = User.by_id!(id)
+
+    {:ok, _} = User.give_user_in_waitlist_access(user)
+
+    users_in_waitlist = User.users_in_waitlist!()
+
+    {:noreply,
+     socket
+     |> put_flash(:info, gettext("User has been given access"))
+     |> assign(users_in_waitlist: users_in_waitlist)}
+  end
+
+  @impl true
+  def handle_info({:display_updated_credits, credits}, socket) do
+    current_user_credit_points =
+      ProfileViewCredits.get_updated_credit_for_current_user(socket.assigns.current_user, credits)
+      |> Points.humanized_points()
+
+    {:noreply,
+     socket
+     |> assign(current_user_credit_points: current_user_credit_points)}
+  end
+
+  def handle_info({:new_message, message}, socket) do
+    unread_messages = socket.assigns.unread_messages ++ [message]
+
+    {:noreply,
+     socket
+     |> assign(unread_messages: unread_messages)
+     |> assign(number_of_unread_messages: Enum.count(unread_messages))}
+  end
+
+  def handle_info({:user, current_user}, socket) do
+    if current_user.state in user_states_to_be_auto_logged_out() do
+      {:noreply,
+       socket
+       |> push_navigate(to: "/auth/user/sign-out?auto_log_out=#{current_user.state}")}
+    else
+      {:noreply,
+       socket
+       |> assign(:current_user, current_user)}
+    end
+  end
+
+  defp user_states_to_be_auto_logged_out do
+    [
+      :under_investigation,
+      :banned,
+      :archived
+    ]
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.waitlist_users_table users={@users_in_waitlist} />
+    </div>
+    """
+  end
+end

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -38,6 +38,7 @@ defmodule AniminaWeb.Router do
 
     ash_authentication_live_session :live_authentication_required,
       on_mount: {AniminaWeb.LiveUserAuth, :live_admin_required} do
+      live "/admin/waitlist", WaitlistLive, :index
       live "/admin/reports/all", AllReportsLive, :index
       live "/admin/reports/pending", PendingReportsLive, :index
       live "/admin/reports/:id", ShowReportLive, :index


### PR DESCRIPTION
- Admins can access `/admin/waitlist` and can remove a user from the waitlist and give them access to the system.
![Screenshot 2024-08-13 at 05 50 21](https://github.com/user-attachments/assets/44035ad9-e916-4c7d-8b1a-c73760dc16c4)
- The user then gets an email informing them they now have access to the system.
- I also added instructions in the README about how to remove a user from the waitlist