### PR TITLE
Fix Link in registration email  , closes #870

### DIFF
--- a/lib/animina/user_email.ex
+++ b/lib/animina/user_email.ex
@@ -11,8 +11,27 @@ defmodule Animina.UserEmail do
   def send(user, confirm, _opts) do
     subject = gettext("👫❤️ Confirm your email address")
 
-    text_body = ~S"""
-    Hi #{user.username}!
+    body =
+      construct_salutation(user) <>
+        construct_email_body() <>
+        construct_link(confirm) <>
+        construct_signature()
+
+    send_email(
+      user.name,
+      Ash.CiString.value(user.email),
+      subject,
+      body
+
+    )
+  end
+
+  defp construct_salutation(user) do
+    "Hi #{user.name}!"
+  end
+
+  defp construct_email_body() do
+    ~S"""
 
     A new ANIMINA https://animina.de account has been created with this
     email address.
@@ -21,14 +40,22 @@ defmodule Animina.UserEmail do
     in case you didn't create the account.
 
     """
+  end
 
-    send_email(
-      user.name,
-      Ash.CiString.value(user.email),
-      subject,
-      text_body <>
-        "\n<a href='#{"#{get_link(Application.get_env(:animina, :env))}/auth/user/confirm_new_user?#{URI.encode_query(confirm: confirm)}"}'>#{gettext("Confirm your email address")}</a>"
-    )
+  defp construct_link(confirm) do
+    "\n#{"#{get_link(Application.get_env(:animina, :env))}/auth/user/confirm_new_user?#{URI.encode_query(confirm: confirm)}"}"
+    <>
+    ~S"""
+
+
+    """
+  end
+
+  defp construct_signature do
+    ~S"""
+    Best regards,
+    ANIMINA Team
+    """
   end
 
   defp get_link(:prod) do

--- a/lib/animina/user_email.ex
+++ b/lib/animina/user_email.ex
@@ -30,7 +30,7 @@ defmodule Animina.UserEmail do
     "Hi #{user.name}!"
   end
 
-  defp construct_email_body() do
+  defp construct_email_body do
     ~S"""
 
     A new ANIMINA https://animina.de account has been created with this


### PR DESCRIPTION
![Screenshot 2024-08-14 at 08 50 09](https://github.com/user-attachments/assets/7ffd7821-2f64-4836-a0f7-9e9140c40dd4)



@wintermeyer  , constructing a url shortener would take time , kindly check 
```
defp construct_signature do
    ~S"""
    Best regards,
    ANIMINA Team
    """
  end
``` 
in `lib/animina/user_email.ex` where  you can add your signature.

- Now we send it with the actual name , previously it went out as #{user.name}! 
