### PR TITLE
Fixed Potential Partners Bug

### DIFF
--- a/lib/animina/accounts/resources/potential_partner.ex
+++ b/lib/animina/accounts/resources/potential_partner.ex
@@ -43,7 +43,16 @@ defmodule Animina.Accounts.PotentialPartner do
   end
 
   actions do
-    defaults [:create, :read]
+    defaults [:read]
+
+    create :create do
+      accept [
+        :user_id,
+        :potential_partner_id
+      ]
+
+      primary? true
+    end
 
     read :potential_partners_for_user do
       argument :user_id, :uuid do

--- a/lib/animina/validations/delete_about_story.ex
+++ b/lib/animina/validations/delete_about_story.ex
@@ -23,13 +23,10 @@ defmodule Animina.Validations.DeleteAboutStory do
 
     user_id = Ash.Changeset.get_attribute(changeset, opts[:user])
 
-  
     case Headline.by_id(headline_id) do
       {:ok, headline} ->
-        if  headline.subject == "About me" do
-          {:error,
-           field: opts[:attribute],
-           message: "You cannot delete the 'About me' story."}
+        if headline.subject == "About me" do
+          {:error, field: opts[:attribute], message: "You cannot delete the 'About me' story."}
         else
           :ok
         end

--- a/test/animina/accounts/story_test.exs
+++ b/test/animina/accounts/story_test.exs
@@ -53,7 +53,7 @@ defmodule Animina.Accounts.StoryTest do
       assert {:error, _} = Story.destroy(about_me_story)
 
       # insert another story
-      {:ok , non_about_me_story} = create_non_about_me_story(user.id, get_non_about_me_headline.id)
+      {:ok, non_about_me_story} = create_non_about_me_story(user.id, get_non_about_me_headline.id)
 
       # now when there is another story with a different headline, you should
       # still not be able to delete the 'About me' story


### PR DESCRIPTION
Users can now see their potential partners , we filter them on


```
    |> partner_not_self_query(user)
    |> partner_not_under_investigation_query(user)
    |> partner_not_banned_query(user)
    |> partner_not_archived_query(user)
    |> partner_not_hibernate_query(user)
    |> partner_not_incognito_query(user)
    |> partner_bookmarked_query(user, remove_bookmarked)
```


And In the dashboard we have


![Screenshot 2024-08-26 at 15 45 12](https://github.com/user-attachments/assets/a6f5a550-20a3-479a-903b-c454ec35939b)
