### PR TITLE
Adjust registration workflow that everybody has to create an "About me" story , closes #944

### DIFF
--- a/lib/animina/validations/delete_about_story.ex
+++ b/lib/animina/validations/delete_about_story.ex
@@ -21,8 +21,6 @@ defmodule Animina.Validations.DeleteAboutStory do
     headline_id =
       Ash.Changeset.get_attribute(changeset, opts[:headline])
 
-    user_id = Ash.Changeset.get_attribute(changeset, opts[:user])
-
     case Headline.by_id(headline_id) do
       {:ok, headline} ->
         if headline.subject == "About me" do

--- a/lib/animina_web/live/auth_live/user_auth.ex
+++ b/lib/animina_web/live/auth_live/user_auth.ex
@@ -6,6 +6,7 @@ defmodule AniminaWeb.LiveUserAuth do
   alias Animina.Accounts.Credit
   alias Animina.Accounts.Message
   alias Animina.Accounts.User
+  alias Animina.Narratives.Story
   alias AniminaWeb.Registration
   import Phoenix.Component
 
@@ -94,6 +95,69 @@ defmodule AniminaWeb.LiveUserAuth do
          :error,
          "You need to be authenticated  confirmed , and have an active account to access this page . If you are already signed up , check your email for the confirmation link"
        )}
+    end
+  end
+
+  def on_mount(:live_user_required_with_about_me_story, _params, session, socket) do
+    path =
+      case Map.get(socket.private.connect_info, :request_path, nil) do
+        nil ->
+          "sign-in"
+
+        path ->
+          case Map.get(socket.private.connect_info, :query_string, nil) do
+            nil ->
+              "sign-in?redirect_to=" <> path
+
+            "" ->
+              "sign-in?redirect_to=" <> path
+
+            query_string ->
+              "sign-in?redirect_to=" <> path <> "?" <> query_string
+          end
+      end
+
+    if socket.assigns[:current_user] && socket.assigns[:current_user].confirmed_at &&
+         user_has_an_about_me_story?(socket.assigns[:current_user]) do
+      current_user =
+        Registration.get_current_user(session)
+
+      add_daily_points_for_user(
+        current_user,
+        100,
+        check_if_user_has_daily_bonus_added_for_the_day(current_user.id)
+      )
+
+      {:ok, unread_messages} = Message.unread_messages_for_user(current_user.id)
+
+      user_in_waitlist_socket(current_user, socket, unread_messages, current_user)
+    else
+      {:halt,
+       socket
+       |> Phoenix.LiveView.redirect(to: "/my/about-me")
+       |> Phoenix.LiveView.put_flash(
+         :error,
+         "You need to have an About me story to access this page"
+       )}
+    end
+  end
+
+  defp user_in_waitlist_socket(user, socket, unread_messages, current_user) do
+    if user.is_in_waitlist do
+      {:halt,
+       socket
+       |> Phoenix.LiveView.redirect(to: "/my/too-successful")
+       |> Phoenix.LiveView.put_flash(
+         :info,
+         "Welcome back"
+       )}
+    else
+      {:cont,
+       socket
+       |> assign(:current_user, current_user)
+       |> assign(:unread_messages, unread_messages)
+       |> assign(:number_of_unread_messages, Enum.count(unread_messages))
+       |> assign(:current_user_credit_points, current_user.credit_points)}
     end
   end
 
@@ -190,6 +254,24 @@ defmodule AniminaWeb.LiveUserAuth do
        socket
        |> Phoenix.LiveView.redirect(to: "/sign-in")}
     end
+  end
+
+  defp user_has_an_about_me_story?(user) do
+    case get_stories_for_a_user(user) do
+      [] ->
+        false
+
+      stories ->
+        Enum.any?(stories, fn story ->
+          story.headline.subject == "About me"
+        end)
+    end
+  end
+
+  defp get_stories_for_a_user(user) do
+    {:ok, stories} = Story.by_user_id(user.id)
+
+    stories
   end
 
   defp user_is_admin(user) do

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -50,14 +50,18 @@ defmodule AniminaWeb.Router do
       live "/my/potential-partner", PotentialPartnerLive, :index
       live "/my/profile-photo", ProfilePhotoLive, :index
       live "/my/profile/edit", UpdateProfileLive, :index
-      live "/my/stories/new", StoryLive, :new
-      live "/my/stories/:id/edit", StoryLive, :edit
-      live "/my/posts/new", PostLive, :new
-      live "/my/posts/:id/edit", PostLive, :edit
       live "/my/flags/white", FlagsLive, :white
       live "/my/flags/green", FlagsLive, :green
       live "/my/flags/red", FlagsLive, :red
       live "/my/about-me", StoryLive, :about_me
+    end
+
+    ash_authentication_live_session :authentication_required_and_about_me_story,
+      on_mount: {AniminaWeb.LiveUserAuth, :live_user_required_with_about_me_story} do
+      live "/my/stories/new", StoryLive, :new
+      live "/my/stories/:id/edit", StoryLive, :edit
+      live "/my/posts/new", PostLive, :new
+      live "/my/posts/:id/edit", PostLive, :edit
       live "/my/bookmarks", BookmarksLive, :bookmarks
       live "/my/bookmarks/:filter_type", BookmarksLive, :bookmarks
       live "/my/messages/:profile", ChatLive, :index

--- a/test/animina_web/live/root_test.exs
+++ b/test/animina_web/live/root_test.exs
@@ -4,6 +4,8 @@ defmodule AniminaWeb.RootTest do
   alias Animina.Accounts.Role
   alias Animina.Accounts.User
   alias Animina.Accounts.UserRole
+  alias Animina.Narratives.Headline
+  alias Animina.Narratives.Story
 
   @valid_attrs %{
     email: "michael@example.com",
@@ -190,6 +192,12 @@ defmodule AniminaWeb.RootTest do
          %{conn: conn} do
       {:ok, user} = User.create(@valid_create_user_attrs)
 
+      create_user_about_me_story(
+        user,
+        get_about_me_headline(),
+        "I am a software engineer"
+      )
+
       current_points = User.by_username!(user.username).credit_points
 
       {:ok, index_live, _html} =
@@ -290,6 +298,12 @@ defmodule AniminaWeb.RootTest do
 
       {:ok, user} = User.update(user, %{is_in_waitlist: true})
 
+      create_user_about_me_story(
+        user,
+        get_about_me_headline(),
+        "I am a software engineer"
+      )
+
       {:ok, _index_live, html} =
         conn
         |> login_user(%{"username_or_email" => user.email, "password" => @valid_attrs.password})
@@ -335,6 +349,34 @@ defmodule AniminaWeb.RootTest do
       form(lv, "#basic_user_sign_in_form", user: attributes)
 
     submit_form(form, conn)
+  end
+
+  defp get_about_me_headline do
+    case Headline.by_subject("About me") do
+      {:ok, headline} ->
+        headline
+
+      _ ->
+        {:ok, headline} =
+          Headline.create(%{
+            subject: "About me",
+            position: 90
+          })
+
+        headline
+    end
+  end
+
+  defp create_user_about_me_story(user, headline, story_content) do
+    {:ok, story} =
+      Story.create(%{
+        user_id: user.id,
+        headline_id: headline.id,
+        content: story_content,
+        position: 1
+      })
+
+    story
   end
 
   defp confirm_user(attributes) do

--- a/test/animina_web/live/update_profile_test.exs
+++ b/test/animina_web/live/update_profile_test.exs
@@ -3,6 +3,8 @@ defmodule AniminaWeb.UpdateProfileTest do
   import Phoenix.LiveViewTest
   alias Animina.Accounts.Credit
   alias Animina.Accounts.User
+  alias Animina.Narratives.Headline
+  alias Animina.Narratives.Story
 
   describe "Tests the Update Profile Live" do
     setup do
@@ -92,7 +94,37 @@ defmodule AniminaWeb.UpdateProfileTest do
         confirmed_at: DateTime.utc_now()
       })
 
+    create_user_about_me_story(user, get_about_me_headline(), "This is my story")
+
     user
+  end
+
+  defp get_about_me_headline do
+    case Headline.by_subject("About me") do
+      {:ok, headline} ->
+        headline
+
+      _ ->
+        {:ok, headline} =
+          Headline.create(%{
+            subject: "About me",
+            position: 90
+          })
+
+        headline
+    end
+  end
+
+  defp create_user_about_me_story(user, headline, story_content) do
+    {:ok, story} =
+      Story.create(%{
+        user_id: user.id,
+        headline_id: headline.id,
+        content: story_content,
+        position: 1
+      })
+
+    story
   end
 
   defp login_user(conn, attributes) do


### PR DESCRIPTION
 - If a user has no about me story , they have the following behaviour when moving to other pages.

https://github.com/user-attachments/assets/a942e3d7-dfd7-4fca-87ba-85c56175959b



The only pages one can access when logged in and without an about me strory are

```
      live "/my/potential-partner", PotentialPartnerLive, :index
      live "/my/profile-photo", ProfilePhotoLive, :index
      live "/my/profile/edit", UpdateProfileLive, :index
      live "/my/flags/white", FlagsLive, :white
      live "/my/flags/green", FlagsLive, :green
      live "/my/flags/red", FlagsLive, :red
      live "/my/about-me", StoryLive, :about_me
```

