### PR TITLE
Set up Reset Password Link  , closes #977 , closes #853

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -40,8 +40,6 @@ input:not([placeholder])[type="tel"],
 input:not([placeholder])[type="time"],
 input:not([placeholder])[type="url"],
 input:not([placeholder])[type="week"] {
-  border: 5px dashed #f30 !important;
-  outline: 5px dashed #f96 !important;
 }
 
 input:disabled,
@@ -71,6 +69,7 @@ input[type="time"],
 input[type="url"],
 input[type="week"] {
   @apply shadow-inner;
+  border: gray 1px solid !important;
 }
 
 input[type="checkbox"],
@@ -83,6 +82,16 @@ input[type="submit"] input[type="reset"],
 button,
 select {
   @apply drop-shadow-lg;
+}
+
+#user-password-password-reset-with-password_password {
+  border: 1px solid gray !important;
+  border-radius: 10px !important;
+}
+
+img[src*="https://ash-hq.org/images/ash-framework-dark.png"]
+{
+  display: none !important;
 }
 
 /*

--- a/config/config.exs
+++ b/config/config.exs
@@ -19,6 +19,7 @@ config :animina, env: Mix.env()
 # Configures the number of stories required for complete registration
 config :animina, :number_of_stories_required_for_complete_registration, 1
 
+
 config :animina,
   ecto_repos: [Animina.Repo],
   generators: [timestamp_type: :utc_datetime]

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -314,6 +314,14 @@ defmodule Animina.Accounts.User do
       prepare Animina.MyCustomSignInPreparation
     end
 
+    read :request_password_reset_with_password do
+      argument :email, Ash.Type.CiString do
+        allow_nil? false
+      end
+
+      prepare AshAuthentication.Strategy.Password.RequestPasswordResetPreparation
+    end
+
     read :by_username_as_an_actor do
       argument :username, :ci_string do
         allow_nil? false
@@ -454,6 +462,7 @@ defmodule Animina.Accounts.User do
     define :by_email, get_by: [:email], action: :read
     define :by_username_as_an_actor, args: [:username]
     define :custom_sign_in, get?: true
+    define :request_password_reset_with_password
     define :female_public_users_who_created_an_account_in_the_last_60_days
     define :male_public_users_who_created_an_account_in_the_last_60_days
     define :users_in_waitlist
@@ -545,6 +554,10 @@ defmodule Animina.Accounts.User do
           :legal_terms_accepted,
           :occupation
         ])
+
+        resettable do
+          sender Animina.SendPasswordResetEmail
+        end
       end
     end
 

--- a/lib/animina/send_password_reset_email.ex
+++ b/lib/animina/send_password_reset_email.ex
@@ -1,0 +1,113 @@
+defmodule Animina.SendPasswordResetEmail do
+  @moduledoc """
+  This module provides the functionality to send emails for password reset.
+  """
+
+  import Swoosh.Email
+  import AniminaWeb.Gettext
+  alias Animina.Mailer
+  use AshAuthentication.Sender
+
+  def send(user, token, _opts) do
+    subject = gettext("👫❤️ Reset Your Password for your ANIMINA account")
+
+    body =
+      construct_salutation(user) <>
+        construct_email_body() <>
+        construct_link(token) <>
+        construct_signature()
+
+    send_email(
+      user.name,
+      Ash.CiString.value(user.email),
+      subject,
+      body
+    )
+
+    IO.puts(construct_link(token))
+  end
+
+  def send_email(
+        receiver_name,
+        receiver_email,
+        subject,
+        text_body
+      )
+      when not is_nil(receiver_name) and not is_nil(receiver_email) and not is_nil(subject) and
+             not is_nil(text_body) do
+    new()
+    |> to({receiver_name, receiver_email})
+    |> from({sender_name(), sender_email()})
+    |> subject(subject)
+    |> text_body(text_body)
+    |> Mailer.deliver()
+  end
+
+  def send_email(
+        receiver_name,
+        receiver_email,
+        subject,
+        text_body,
+        html_body
+      )
+      when not is_nil(receiver_name) and not is_nil(receiver_email) and not is_nil(subject) and
+             not is_nil(text_body) and
+             not is_nil(html_body) do
+    new()
+    |> to({receiver_name, receiver_email})
+    |> from({sender_name(), sender_email()})
+    |> subject(subject)
+    |> html_body(html_body)
+    |> text_body(text_body)
+    |> Mailer.deliver()
+  end
+
+  defp construct_salutation(user) do
+    "Hi #{user.name}!\n"
+  end
+
+  defp construct_email_body do
+    ~S"""
+
+    Your password reset request has been received.
+
+    Please click the link below to reset your password.
+
+    """
+  end
+
+  defp construct_link(token) do
+    "\n #{"#{get_link(Application.get_env(:animina, :env))}/password-reset/#{token}"}\n"
+  end
+
+  defp construct_signature do
+    ~S"""
+
+
+    Best regards,
+      ANIMINA Team
+
+    --
+    This email was sent by the ANIMINA system. Please do not reply to it.
+    I am just dumb software and can't read your emails. Do contact my
+    human boss Stefan Wintermeyer <stefan@wintermeyer.de> in case you
+    have any questions or concerns.
+    """
+  end
+
+  defp get_link(:prod) do
+    "https://animina.de"
+  end
+
+  defp get_link(_) do
+    "http://localhost:4000"
+  end
+
+  defp sender_name do
+    "ANIMINA System"
+  end
+
+  defp sender_email do
+    "system@animina.de"
+  end
+end

--- a/lib/animina/validations/mobile_phone_number.ex
+++ b/lib/animina/validations/mobile_phone_number.ex
@@ -15,9 +15,13 @@ defmodule Animina.Validations.MobilePhoneNumber do
 
   @impl true
   def validate(changeset, opts, _context) do
-    Ash.Changeset.get_attribute(changeset, opts[:attribute])
-    |> extract_ex_phone_number()
-    |> validate_mobile_phone_number(opts)
+    if changeset.action.name == :password_reset_with_password do
+      :ok
+    else
+      Ash.Changeset.get_attribute(changeset, opts[:attribute])
+      |> extract_ex_phone_number()
+      |> validate_mobile_phone_number(opts)
+    end
   end
 
   defp extract_ex_phone_number(raw_attribute) do

--- a/lib/animina/validations/must_be_true.ex
+++ b/lib/animina/validations/must_be_true.ex
@@ -15,10 +15,14 @@ defmodule Animina.Validations.MustBeTrue do
 
   @impl true
   def validate(changeset, opts, _context) do
-    case Ash.Changeset.get_attribute(changeset, opts[:attribute]) do
-      nil -> :ok
-      true -> :ok
-      _ -> {:error, field: opts[:attribute], message: "must be true"}
+    if changeset.action.name == :password_reset_with_password do
+      :ok
+    else
+      case Ash.Changeset.get_attribute(changeset, opts[:attribute]) do
+        nil -> :ok
+        true -> :ok
+        _ -> {:error, field: opts[:attribute], message: "must be true"}
+      end
     end
   end
 end

--- a/lib/animina_web/live/request_password_live.ex
+++ b/lib/animina_web/live/request_password_live.ex
@@ -1,0 +1,109 @@
+defmodule AniminaWeb.RequestPasswordLive do
+  use AniminaWeb, :live_view
+  alias Animina.Accounts
+  alias Animina.Accounts.User
+  alias Animina.GenServers.ProfileViewCredits
+  alias AshPhoenix.Form
+
+  @impl true
+  def mount(_params, %{"language" => language} = _session, socket) do
+    socket =
+      socket
+      |> assign(language: language)
+      |> assign(current_user: nil)
+      |> assign(trigger_action: false)
+      |> assign(current_user_credit_points: 0)
+      |> assign(:errors, [])
+      |> assign(page_title: gettext("Request Password Reset"))
+      |> assign(:cta, gettext("Send Reset Password Link"))
+      |> assign(active_tab: :register)
+      |> assign(page_title: "Animina #{gettext("Request Password Reset")}")
+      |> assign(:action, "/auth/user/password/reset_request")
+      |> assign(
+        :form,
+        Form.for_create(User, :register_with_password, domain: Accounts, as: "user")
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_event("validate", %{"user" => user}, socket) do
+    form = Form.validate(socket.assigns.form, user, errors: true)
+
+    {:noreply, socket |> assign(form: form)}
+  end
+
+  @impl true
+  def handle_event("submit", %{"user" => user}, socket) do
+    form = Form.validate(socket.assigns.form, user)
+
+    {:noreply,
+     socket
+     |> assign(:form, form)
+     |> assign(:errors, Form.errors(form))
+     |> assign(:trigger_action, true)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="px-5 space-y-10">
+      <.form
+        :let={f}
+        id="basic_user_form"
+        for={@form}
+        action={@action}
+        phx-trigger-action={@trigger_action}
+        method="POST"
+        class="space-y-6 group "
+        phx-change="validate"
+        phx-submit="submit"
+      >
+        <p class="text-xl dark:text-white text-black font-medium">
+          <%= gettext("Enter your email address to receive a password reset link") %>
+        </p>
+
+        <div class="w-[100%] md:grid grid-cols-1 gap-1">
+          <label
+            for="user_email"
+            class="block text-sm font-medium leading-6 text-gray-900 dark:text-white"
+          >
+            <%= gettext("E-mail address") %>
+          </label>
+          <div phx-feedback-for={f[:email].name} class="mt-2">
+            <%= text_input(f, :email,
+              class:
+                "block w-full rounded-md border-0 py-1.5 dark:bg-gray-700  dark:text-white text-gray-900 shadow-sm ring-1 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-inset sm:text-sm  phx-no-feedback:ring-gray-300 phx-no-feedback:focus:ring-indigo-600 sm:leading-6 ",
+              placeholder: gettext("alice@example.net"),
+              value: f[:email].value,
+              required: true,
+              autocomplete: :email,
+              "phx-debounce": "200"
+            ) %>
+          </div>
+          <div class="mt-3">
+            <.link navigate="/sign-in">
+              <p class="block text-sm leading-6 text-blue-600 transition-all duration-500 ease-in-out hover:text-blue-500 dark:hover:text-blue-500 hover:cursor-pointer hover:underline">
+                <%= gettext("Back to Sign In") %>
+              </p>
+            </.link>
+          </div>
+
+          <div class="mt-4">
+            <%= submit(@cta,
+              class:
+                "flex w-full justify-center rounded-md bg-indigo-600 dark:bg-indigo-500 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 "
+            ) %>
+          </div>
+        </div>
+      </.form>
+    </div>
+    """
+  end
+end

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -578,10 +578,15 @@ defmodule AniminaWeb.RootLive do
           </div>
         </div>
 
-        <div>
+        <div class="w-[100%] flex justify-between items-center">
           <.link navigate={@sign_up_link}>
             <p class="block text-sm leading-6 text-blue-600 transition-all duration-500 ease-in-out hover:text-blue-500 dark:hover:text-blue-500 hover:cursor-pointer hover:underline">
               <%= gettext("Don't have an account? Sign up") %>
+            </p>
+          </.link>
+          <.link navigate="/reset-password">
+            <p class="block text-sm leading-6 text-blue-600 transition-all duration-500 ease-in-out hover:text-blue-500 dark:hover:text-blue-500 hover:cursor-pointer hover:underline">
+              <%= gettext("Forgot Your Password?") %>
             </p>
           </.link>
         </div>

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -24,6 +24,7 @@ defmodule AniminaWeb.Router do
     ash_authentication_live_session :authentication_optional,
       on_mount: {AniminaWeb.LiveUserAuth, :live_no_user} do
       live "/sign-in", RootLive, :sign_in
+      live "/reset-password", RequestPasswordLive, :index
     end
 
     ash_authentication_live_session :authentication_required_for_email_validation,
@@ -86,9 +87,11 @@ defmodule AniminaWeb.Router do
     end
 
     post "/auth/user/sign_in/", AuthController, :sign_in
+    post "/auth/user/request_password", AuthController, :request_password
 
     sign_out_route AuthController, "/auth/user/sign-out"
     auth_routes_for Animina.Accounts.User, to: AuthController
+
     reset_route []
   end
 


### PR DESCRIPTION
- We now have a link to the reset password page on the login page
![Screenshot 2024-08-29 at 09 28 19](https://github.com/user-attachments/assets/bc019ef5-3d89-4c3f-bec4-5223da967dff)



- When you add your email account , we send you an email with that link 
- 
![Screenshot 2024-08-29 at 09 28 30](https://github.com/user-attachments/assets/65ab8ca1-3f4b-4074-b394-33cfa9a9254d)
![Screenshot 2024-08-29 at 09 33 33](https://github.com/user-attachments/assets/1a54b446-ed38-45e4-a775-c60d27b0d5c6)

- when you click on that link , you can then reset your password


![Screenshot 2024-08-29 at 09 34 02](https://github.com/user-attachments/assets/05d44f79-7c07-46fb-96de-ca206afb9340)





@wintermeyer  , if this PR is okay , kindly let the user who raised it know , they were not able to log into the system yesterday