### PR TITLE
remove redundant mount/3 in profile_live, closes #1049

### DIFF
--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -312,11 +312,6 @@ defmodule AniminaWeb.ProfileLive do
     end
   end
 
-  defp redirect_to_username(socket, username) do
-    socket
-    |> push_navigate(to: ~p"/#{username}")
-  end
-
   defp subscribe(socket, current_user, user) do
     if connected?(socket) do
       PubSub.subscribe(Animina.PubSub, "credits")

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -237,6 +237,19 @@ defmodule AniminaWeb.ProfileLive do
     end
   end
 
+  def mount(_params, %{"language" => _language}, socket) do
+    current_user =
+      socket.assigns.current_user
+
+    if current_user do
+      {:ok,
+       socket
+       |> push_navigate(to: ~p"/#{current_user.username}")}
+    else
+      raise Animina.Fallback
+    end
+  end
+
   def mount(_params, %{"language" => _language}, _socket) do
     raise Animina.Fallback
   end

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -250,7 +250,7 @@ defmodule AniminaWeb.ProfileLive do
     end
   end
 
-  def mount(_params, %{"language" => _language}, _socket) do
+  def mount(_params, _session, _socket) do
     raise Animina.Fallback
   end
 

--- a/lib/animina_web/live/profile_live.ex
+++ b/lib/animina_web/live/profile_live.ex
@@ -222,7 +222,7 @@ defmodule AniminaWeb.ProfileLive do
   end
 
   @impl true
-  def mount(%{"username" => username}, %{"language" => language, "user" => _}, socket) do
+  def mount(%{"username" => username}, %{"language" => language}, socket) do
     socket =
       socket
       |> assign(language: language)
@@ -234,110 +234,6 @@ defmodule AniminaWeb.ProfileLive do
       profile_socket(socket, username, language, current_user, :same_profile)
     else
       profile_socket(socket, username, language, current_user)
-    end
-  end
-
-  def mount(%{"username" => username}, %{"language" => language}, socket) do
-    socket =
-      socket
-      |> assign(language: language)
-      |> assign(active_tab: "")
-
-    case Accounts.User.by_username(username) do
-      {:ok, user} ->
-        if show_optional_404_page(user, nil) ||
-             user.state in user_states_not_visible_to_anonymous_users() ||
-             user.registration_completed_at == nil do
-          raise Animina.Fallback
-        else
-          {:ok,
-           socket
-           |> assign(user: user)
-           |> assign(page_title: "#{user.name} - #{gettext("Animina Profile")}")
-           |> assign(current_user_credit_points: 0)
-           |> assign(intersecting_green_flags_count: 0)
-           |> assign(intersecting_red_flags_count: 0)
-           |> assign(intersecting_green_flags: [])
-           |> assign(intersecting_red_flags: [])
-           |> assign(show_404_page: false)
-           |> assign(profile_points: Points.humanized_points(user.credit_points))
-           |> assign(
-             current_user_has_liked_profile?: current_user_has_liked_profile(nil, user.id)
-           )
-           |> redirect_if_username_is_different(username, user)}
-        end
-
-      _ ->
-        raise Animina.Fallback
-    end
-  end
-
-  def mount(_params, %{"language" => language, "user" => _}, socket) do
-    socket =
-      socket
-      |> assign(language: language)
-      |> assign(active_tab: :profile)
-
-    current_user =
-      socket.assigns.current_user
-
-    username = current_user.username
-
-    case Accounts.User.by_username_as_an_actor(username, actor: current_user) do
-      {:ok, user} ->
-        subscribe(socket, current_user, user)
-
-        if connected?(socket) do
-          create_or_update_visited_bookmark(current_user, user)
-
-          deduct_points_for_first_profile_view(current_user, user)
-        end
-
-        add_points_for_viewing_to_profile(current_user.id, user.id, socket)
-
-        visit_log_entry =
-          create_visit_log_entry_for_bookmark_and_user(current_user, user, socket)
-
-        update_visit_log_entry_for_bookmark_and_user(current_user, user)
-
-        intersecting_green_flags_count =
-          get_intersecting_flags_count(
-            filter_flags(current_user, :green, language),
-            filter_flags(user, :white, language)
-          )
-
-        intersecting_red_flags_count =
-          get_intersecting_flags_count(
-            filter_flags(current_user, :red, language),
-            filter_flags(user, :white, language)
-          )
-
-        if show_optional_404_page(user, current_user) do
-          raise Animina.Fallback
-        else
-          {:ok,
-           socket
-           |> assign(user: user)
-           |> assign(visit_log_entry: visit_log_entry)
-           |> assign(
-             current_user_credit_points:
-               Points.humanized_points(socket.assigns.current_user.credit_points)
-           )
-           |> assign(intersecting_green_flags_count: intersecting_green_flags_count)
-           |> assign(intersecting_green_flags: [])
-           |> assign(intersecting_red_flags: [])
-           |> assign(page_title: "#{user.name} - #{gettext("Animina Profile")}")
-           |> assign(intersecting_red_flags_count: intersecting_red_flags_count)
-           |> assign(profile_points: Points.humanized_points(user.credit_points))
-           |> assign(
-             current_user_has_liked_profile?:
-               current_user_has_liked_profile(socket.assigns.current_user, user.id)
-           )
-           |> redirect_to_username(username)}
-        end
-
-      _ ->
-        raise Animina.Fallback
     end
   end
 


### PR DESCRIPTION
I've removed some redundant mount/3 code as its covered by the profile_socket functions. I've tested it both logged in and logged out and it works.