### PR TITLE
Removed Photo Tagging temporarily

### DIFF
--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -182,8 +182,6 @@ defmodule Animina.Accounts.Photo do
 
     change after_action(fn changeset, record, _ ->
              create_optimized_photos(record)
-             create_photo_flags(record)
-             #  spawn(fn -> create_photo_flags(record) end)
 
              {:ok, record}
            end),


### PR DESCRIPTION
- I removed the photo tagging we have (where it happens ) as it was taking too long and stories /profile photos could not be created , @Kimutai01  , is working on a better place to trigger this mechanism