### PR TITLE
add action to get intersecting flags, closes #1056

### DIFF
--- a/lib/animina/traits/resources/user_flags.ex
+++ b/lib/animina/traits/resources/user_flags.ex
@@ -1,6 +1,6 @@
 defmodule Animina.Traits.UserFlags do
-  alias Animina.Validations
   alias Animina.Repo
+  alias Animina.Validations
 
   import Ecto.Query
 

--- a/test/animina/accounts/user_flags_test.exs
+++ b/test/animina/accounts/user_flags_test.exs
@@ -45,11 +45,11 @@ defmodule Animina.Accounts.UserFlagsTest do
       # create user two white flags
       {:ok, _user_flag} = create_user_flag(user_two, flag, :white)
 
-      # get intersecting flags
+      # user one has green flags intersecting with user two's white flags
       assert {:ok, [_flag | _]} = intersecting_flags(user.id, user_two.id, "green", "white")
 
-      # assert {:ok, _user_flag} = create_user_flag(user, flag, :green)
-      # assert {:error, _} = create_user_flag(user, flag, :red)
+      # user one has no white flags intersecting with user two's white flags
+      assert {:ok, []} = intersecting_flags(user.id, user_two.id, "white", "white")
     end
   end
 


### PR DESCRIPTION
I have added an action which uses only 1 sql query to get intersecting flags for two users based on color.
The action uses Ecto.Query instead of Ash.Query, enabling subqueries (to load flag and flag_translations), joins and grouping at the data_layer.
Suggestions to improve this action are welcome.