### PR TITLE
Added Update Photo Feature for stories  , closes #1067

### DIFF
--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -7,6 +7,9 @@ defmodule Animina.Accounts.Photo do
   alias Animina.Accounts.PhotoFlags
   alias Animina.ImageTagging
   alias Animina.Narratives
+  alias Animina.Validations
+
+  Animina.Validations.AboutPhoto
 
   alias Animina.Traits.Flag
 
@@ -192,6 +195,10 @@ defmodule Animina.Accounts.Photo do
              {:ok, record}
            end),
            on: [:create, :destroy]
+  end
+
+  validations do
+    validate {Validations.AboutPhoto, story: :story_id, user: :user_id}, on: :destroy
   end
 
   attributes do

--- a/lib/animina/narratives/resources/story.ex
+++ b/lib/animina/narratives/resources/story.ex
@@ -27,6 +27,7 @@ defmodule Animina.Narratives.Story do
     define :update
     define :destroy
     define :by_id, get_by: [:id], action: :read
+    define :by_id_with_headline, args: [:id], get?: true
     define :by_user_id_with_headline, args: [:user_id]
     define :by_user_id, args: [:user_id]
     define :descending_by_user_id, args: [:user_id]
@@ -90,6 +91,18 @@ defmodule Animina.Narratives.Story do
       prepare build(load: [:headline])
 
       filter expr(user_id == ^arg(:user_id))
+    end
+
+    read :by_id_with_headline do
+      pagination offset?: true, keyset?: true, required?: false
+
+      argument :id, :uuid do
+        allow_nil? false
+      end
+
+      prepare build(load: [:headline])
+
+      filter expr(id == ^arg(:id))
     end
 
     read :descending_by_user_id do

--- a/lib/animina/validations/about_photo.ex
+++ b/lib/animina/validations/about_photo.ex
@@ -1,6 +1,6 @@
 defmodule Animina.Validations.AboutPhoto do
   use Ash.Resource.Validation
-  alias Animina.Accounts.Photo
+  alias Animina.Narratives.Story
 
   @moduledoc """
   This is a module for validating the 'About me' story has a photo

--- a/lib/animina/validations/about_photo.ex
+++ b/lib/animina/validations/about_photo.ex
@@ -1,0 +1,39 @@
+defmodule Animina.Validations.AboutPhoto do
+  use Ash.Resource.Validation
+  alias Animina.Accounts.Photo
+
+  @moduledoc """
+  This is a module for validating the 'About me' story has a photo
+  """
+
+  @impl true
+  def init(opts) do
+    case is_atom(opts[:attribute]) do
+      true -> {:ok, opts}
+      _ -> {:error, "attribute must be an atom!"}
+    end
+  end
+
+  @impl true
+  def validate(changeset, opts, _context) do
+    if changeset.data.story_id do
+      check_if_story_is_about_me(changeset, opts)
+    else
+      :ok
+    end
+  end
+
+  defp check_if_story_is_about_me(changeset, opts) do
+    case Story.by_id_with_headline(changeset.data.story_id) do
+      {:ok, story} ->
+        if story.headline.subject == "About me" do
+          {:error, field: opts[:attribute], message: "The About me story must have a photo."}
+        else
+          :ok
+        end
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/lib/animina/validations/about_story.ex
+++ b/lib/animina/validations/about_story.ex
@@ -1,6 +1,7 @@
 defmodule Animina.Validations.AboutStory do
   use Ash.Resource.Validation
   alias Animina.Narratives.Headline
+
   alias Animina.Narratives.Story
 
   @moduledoc """


### PR DESCRIPTION
- You can now update a photo for a story , for the "About me" story , we remove the `story_id` and for all other stories , we delete the photo that was there previously before uploading the new one.
- I also added validations at Photo resource level to ensure users cannot delete an "About me" photo.
![Screenshot 2024-10-04 at 14 52 39](https://github.com/user-attachments/assets/041cf728-5b79-4036-86cf-3f1bcf7e9003)

https://github.com/user-attachments/assets/f5113412-5193-4e69-a854-04b6e194ba44

