### PR TITLE
Fix photo atom state bug

### DIFF
--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -92,9 +92,6 @@ defmodule AniminaWeb.StoriesComponents do
         </h3>
       </div>
       <div class="pb-2">
-        <p>
-          <%= @story.photo.state %>
-        </p>
         <.story_body
           story={@story}
           user={@user}

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -17,6 +17,9 @@ defmodule AniminaWeb.StoriesComponents do
   attr :user, :any, required: false
   attr :language, :any, required: true
 
+  # we display the state as an atom in the photo struct, but we need to make sure it is an atom
+  # as we are using it for pattern matching
+
   def stories_display(assigns) do
     ~H"""
     <div class="flex flex-col gap-4">
@@ -71,6 +74,7 @@ defmodule AniminaWeb.StoriesComponents do
           }
           src={Photo.get_optimized_photo_to_use(@story.photo, :normal)}
           alt={@story.headline.subject}
+          id={"photo-for-story-#{@story.id}"}
           class="absolute inset-0 object-cover w-full h-full -z-10"
         />
 
@@ -88,6 +92,9 @@ defmodule AniminaWeb.StoriesComponents do
         </h3>
       </div>
       <div class="pb-2">
+        <p>
+          <%= @story.photo.state %>
+        </p>
         <.story_body
           story={@story}
           user={@user}

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -29,6 +29,13 @@ defmodule AniminaWeb.StoriesComponents do
             language={@language}
             delete_story_modal_text={@delete_story_modal_text}
             user={@user}
+            state={
+              if @story.photo && is_atom(@story.photo.state) do
+                @story.photo.state
+              else
+                make_sure_photo_state_is_atom(@story.photo)
+              end
+            }
             current_user_green_flags={@current_user_green_flags}
             current_user_red_flags={@current_user_red_flags}
           />
@@ -192,6 +199,14 @@ defmodule AniminaWeb.StoriesComponents do
 
   defp get_photo_state_name(_, language) do
     with_locale(language, fn -> gettext("Error") end)
+  end
+
+  defp make_sure_photo_state_is_atom(nil) do
+    ""
+  end
+
+  defp make_sure_photo_state_is_atom(photo) do
+    String.to_atom(photo.state)
   end
 
   attr :story, :any, required: true

--- a/lib/animina_web/components/profile/stories_components.ex
+++ b/lib/animina_web/components/profile/stories_components.ex
@@ -48,6 +48,7 @@ defmodule AniminaWeb.StoriesComponents do
   attr :current_user_green_flags, :list, required: true
   attr :current_user_red_flags, :list, required: true
   attr :delete_story_modal_text, :string, required: true
+  attr :state, :any, required: true
 
   def story_card(assigns) do
     ~H"""
@@ -59,7 +60,7 @@ defmodule AniminaWeb.StoriesComponents do
         <img
           :if={
             (@current_user && @story.user_id == @current_user.id) ||
-              display_image(@story.photo.state, @current_user, @story)
+              display_image(@state, @current_user, @story)
           }
           src={Photo.get_optimized_photo_to_use(@story.photo, :normal)}
           alt={@story.headline.subject}
@@ -68,21 +69,14 @@ defmodule AniminaWeb.StoriesComponents do
 
         <h3 class="mt-3 text-lg font-semibold leading-6 text-white">
           <span class="absolute inset-0"></span> <%= @story.headline.subject %>
-
-          <%= state =
-            if(
-              is_atom(@story.photo.state),
-              do: @story.photo.state,
-              else: String.to_atom(@story.photo.state)
-            ) %>
           <p
             :if={
-              @current_user && @story.photo.state != :approved &&
+              @current_user && @state != :approved &&
                 (@story.user_id == @current_user.id || admin_user?(@current_user))
             }
-            class={"p-1 text-[10px] #{get_photo_state_styling(state)} absolute top-2 left-2 rounded-md "}
+            class={"p-1 text-[10px] #{get_photo_state_styling(@state)} absolute top-2 left-2 rounded-md "}
           >
-            <%= get_photo_state_name(state, @language) %>
+            <%= get_photo_state_name(@state, @language) %>
           </p>
         </h3>
       </div>

--- a/lib/animina_web/components/profile/story_component.ex
+++ b/lib/animina_web/components/profile/story_component.ex
@@ -25,6 +25,9 @@ defmodule AniminaWeb.StoryComponent do
     {:ok, socket}
   end
 
+  # we display the state as an atom in the photo struct, but we need to make sure it is an atom
+  # as we are using it for pattern matching
+
   defp make_sure_photo_state_is_atom(nil) do
     ""
   end

--- a/lib/animina_web/components/profile/story_component.ex
+++ b/lib/animina_web/components/profile/story_component.ex
@@ -25,6 +25,14 @@ defmodule AniminaWeb.StoryComponent do
     {:ok, socket}
   end
 
+  defp make_sure_photo_state_is_atom(nil) do
+    ""
+  end
+
+  defp make_sure_photo_state_is_atom(photo) do
+    String.to_atom(photo.state)
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -34,6 +42,13 @@ defmodule AniminaWeb.StoryComponent do
         current_user={@current_user}
         dom_id={@dom_id}
         user={@user}
+        state={
+          if @story.photo && is_atom(@story.photo.state) do
+            @story.photo.state
+          else
+            make_sure_photo_state_is_atom(@story.photo)
+          end
+        }
         current_user_green_flags={@current_user_green_flags}
         language={@language}
         current_user_red_flags={@current_user_red_flags}

--- a/test/animina_web/live/profile_test.exs
+++ b/test/animina_web/live/profile_test.exs
@@ -141,6 +141,25 @@ defmodule AniminaWeb.ProfileTest do
       assert bookmark.reason == :visited
     end
 
+    test "Story images that have been approved are displayed", %{
+      conn: conn,
+      public_user: public_user,
+      private_user: private_user,
+      private_user_story: private_user_story
+    } do
+      {:ok, index_live, html} =
+        conn
+        |> login_user(%{
+          "username_or_email" => public_user.username,
+          "password" => "MichaelTheEngineer"
+        })
+        |> live(~p"/#{private_user.username}")
+
+      assert html =~ private_user.name
+      # since the photo is approved , we will see it in the profile
+      assert has_element?(index_live, "#photo-for-story-#{private_user_story.id}")
+    end
+
     test "Once  a logged in user views a profile , a bookmark is created  and a visit log entry ",
          %{
            conn: conn,
@@ -556,6 +575,21 @@ defmodule AniminaWeb.ProfileTest do
         position: 1
       })
 
+    file_path = Temp.path!(basedir: "priv/static/uploads", suffix: ".jpg")
+
+    file_path_without_uploads = String.replace(file_path, "uploads/", "")
+
+    Photo.create(%{
+      user_id: user.id,
+      filename: file_path_without_uploads,
+      original_filename: file_path_without_uploads,
+      size: 100,
+      ext: "jpg",
+      story_id: story.id,
+      mime: "image/jpeg",
+      state: :approved
+    })
+
     story
   end
 
@@ -570,7 +604,8 @@ defmodule AniminaWeb.ProfileTest do
       original_filename: file_path_without_uploads,
       size: 100,
       ext: "jpg",
-      mime: "image/jpeg"
+      mime: "image/jpeg",
+      state: :approved
     })
   end
 


### PR DESCRIPTION
I noticed a bug where sometimes we have the state as "approved" , String , instead of :approved , atom , this PR ensures we only use the atom version of it.
<img width="1440" alt="Screenshot 2024-11-12 at 09 20 49" src="https://github.com/user-attachments/assets/ae4314d3-af4e-4fde-843a-014753185038">
