### PR TITLE
Fixed Reset Password Link Bug

### DIFF
--- a/lib/animina_web/controllers/auth_controller.ex
+++ b/lib/animina_web/controllers/auth_controller.ex
@@ -9,7 +9,12 @@ defmodule AniminaWeb.AuthController do
   alias AshAuthentication.TokenResource
 
   def success(conn, activity, user, _token) do
-    user = User.by_id!(user.id)
+    user =
+      if user do
+        User.by_id!(user.id)
+      else
+        nil
+      end
 
     return_to =
       case Map.get(conn.query_params, "redirect_to") do


### PR DESCRIPTION
There was a bug where after the email is sent  when resetting your password, the page does not redirect back home

![Screenshot 2024-11-13 at 12 10 37](https://github.com/user-attachments/assets/2c966cb4-eb9d-4ed1-bb80-673aaa97ce2a)


I fixed this by checking if there is a user