### PR TITLE
Handling of Profile Photo and About Me Photo 

### DIFF
--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -9,7 +9,6 @@ defmodule Animina.Accounts.Photo do
   alias Animina.ImageTagging
   alias Animina.Narratives
   alias Animina.Narratives.Story
-  alias Ash.Changeset
 
   alias Animina.Traits.Flag
 
@@ -448,23 +447,6 @@ defmodule Animina.Accounts.Photo do
 
     if story.headline.subject == "About me" do
       User.hibernate(user)
-    end
-  end
-
-  defp activate_or_deactivate_user(user_id) do
-    user =
-      Accounts.User.by_id!(user_id)
-
-    case Narratives.Story.by_user_id(user_id) do
-      {:ok, stories} ->
-        if Enum.count(stories) >=
-             Application.get_env(:animina, :number_of_stories_required_for_complete_registration) and
-             user.registration_completed_at == nil and user.profile_photo != nil do
-          Accounts.User.update(user, %{registration_completed_at: DateTime.utc_now()})
-        end
-
-      _ ->
-        :ok
     end
   end
 

--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -5,11 +5,11 @@ defmodule Animina.Accounts.Photo do
   alias Animina.Accounts
   alias Animina.Accounts.OptimizedPhoto
   alias Animina.Accounts.PhotoFlags
+  alias Animina.Accounts.User
   alias Animina.ImageTagging
   alias Animina.Narratives
-  alias Animina.Validations
-
-  Animina.Validations.AboutPhoto
+  alias Animina.Narratives.Story
+  alias Ash.Changeset
 
   alias Animina.Traits.Flag
 
@@ -201,9 +201,24 @@ defmodule Animina.Accounts.Photo do
 
     change after_action(fn changeset, record, _ ->
              update_user_registration_completed_at(record.user_id)
+
              {:ok, record}
            end),
            on: [:create, :destroy]
+
+    change after_action(fn changeset, record, _ ->
+             maybe_reactivate_user(record.user_id, record.story_id)
+
+             {:ok, record}
+           end),
+           on: [:create]
+
+    change after_action(fn changeset, record, _ ->
+             maybe_hibernate_user(record.user_id, record.story_id)
+
+             {:ok, record}
+           end),
+           on: [:destroy]
 
     change after_action(fn changeset, record, _ ->
              delete_photo_and_optimized_photos(record)
@@ -211,10 +226,6 @@ defmodule Animina.Accounts.Photo do
              {:ok, record}
            end),
            on: [:destroy]
-  end
-
-  validations do
-    validate {Validations.AboutPhoto, story: :story_id, user: :user_id}, on: :destroy
   end
 
   attributes do
@@ -381,6 +392,100 @@ defmodule Animina.Accounts.Photo do
       _ ->
         :ok
     end
+  end
+
+  # We pattern match for nil in story as for a profile picture we don't have a story_id.
+  # This is used for when someone uploads a profile picture.
+  defp maybe_reactivate_user(user_id, nil) do
+    user =
+      Accounts.User.by_id!(user_id)
+
+    case user.state do
+      :normal ->
+        :ok
+
+      :validated ->
+        :ok
+
+      _ ->
+        if user_has_an_about_me_story_with_image?(user) do
+          User.reactivate(user)
+        end
+    end
+  end
+
+  # We pattern match for the story_id as we are targeting an upload for the 'About me' story.
+
+  defp maybe_reactivate_user(user_id, story_id) do
+    story =
+      Narratives.Story.by_id_with_headline!(story_id)
+
+    user =
+      Accounts.User.by_id!(user_id)
+
+    if user.profile_photo != nil and story.headline.subject == "About me" do
+      User.reactivate(user)
+    end
+  end
+
+  # We pattern match for nil in story as for a profile picture we don't have a story_id.
+  # This is used for when someone destroys / deletes a profile picture.
+  defp maybe_hibernate_user(user_id, nil) do
+    user =
+      Accounts.User.by_id!(user_id)
+
+    User.hibernate(user)
+  end
+
+  # We pattern match for the story_id as we are targeting a deletion for the 'About me' story.
+
+  defp maybe_hibernate_user(user_id, story_id) do
+    story =
+      Narratives.Story.by_id_with_headline!(story_id)
+
+    user =
+      Accounts.User.by_id!(user_id)
+
+    if story.headline.subject == "About me" do
+      User.hibernate(user)
+    end
+  end
+
+  defp activate_or_deactivate_user(user_id) do
+    user =
+      Accounts.User.by_id!(user_id)
+
+    case Narratives.Story.by_user_id(user_id) do
+      {:ok, stories} ->
+        if Enum.count(stories) >=
+             Application.get_env(:animina, :number_of_stories_required_for_complete_registration) and
+             user.registration_completed_at == nil and user.profile_photo != nil do
+          Accounts.User.update(user, %{registration_completed_at: DateTime.utc_now()})
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp user_has_an_about_me_story_with_image?(user) do
+    case get_stories_for_a_user(user) do
+      [] ->
+        false
+
+      stories ->
+        stories
+        |> Enum.find(fn story -> story.headline.subject == "About me" end)
+        |> case do
+          nil -> false
+          story -> not is_nil(story.photo)
+        end
+    end
+  end
+
+  defp get_stories_for_a_user(user) do
+    {:ok, stories} = Story.by_user_id(user.id)
+    stories
   end
 
   def extract_uploads_path(path) do

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -303,7 +303,7 @@ defmodule AniminaWeb.ProfilePhotoLive do
           </p>
           <div class="md:w-[300px] w-[100%] relative">
             <div
-              class="absolute z-50 top-4 right-2 h-[40px] text-white w-[40px] bg-red-500 p-2 rounded-md "
+              class="absolute z-50 cursor-pointer top-4 right-2 h-[40px] text-white w-[40px] bg-red-500 p-2 rounded-md "
               phx-click="delete_photo"
               data-confirm={
                 with_locale(@language, fn ->

--- a/lib/animina_web/live/profile_photo_live.ex
+++ b/lib/animina_web/live/profile_photo_live.ex
@@ -302,6 +302,31 @@ defmodule AniminaWeb.ProfilePhotoLive do
             <% end) %>
           </p>
           <div class="md:w-[300px] w-[100%] relative">
+            <div
+              class="absolute z-50 top-4 right-2 h-[40px] text-white w-[40px] bg-red-500 p-2 rounded-md "
+              phx-click="delete_photo"
+              data-confirm={
+                with_locale(@language, fn ->
+                  gettext(
+                    "Are you sure you want to delete your profile photo ? This will hibernate your account until you upload another photo"
+                  )
+                end)
+              }
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </div>
+
             <img
               class="object-cover md:h-200  drop-shadow border md:w-[300px] w-[100%] rounded-lg"
               src={Photo.get_optimized_photo_to_use(@current_user.profile_photo, :normal)}

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -465,6 +465,18 @@ defmodule AniminaWeb.StoryLive do
     end
   end
 
+  def handle_event("delete_photo", _params, socket) do
+    Photo.destroy(socket.assigns.photo)
+
+    {:noreply,
+     socket
+     |> put_flash(
+       :info,
+       with_locale(socket.assigns.language, fn -> gettext("Photo removed successfully !") end)
+     )
+     |> push_navigate(to: ~p"/my/stories/#{socket.assigns.story.id}/edit")}
+  end
+
   def handle_event("generate_story", _params, socket) do
     process_story(
       socket,
@@ -1017,11 +1029,42 @@ defmodule AniminaWeb.StoryLive do
               <%= gettext("Photo") %>
             <% end) %>
           </p>
-
-          <img
-            class="object-cover md:h-200  drop-shadow border md:w-[300px] w-[100%] rounded-lg"
-            src={Photo.get_optimized_photo_to_use(@photo, :normal)}
-          />
+          <div class="md:w-[300px] w-[100%] relative">
+            <div
+              class="absolute z-50 top-4 right-2 h-[40px] cursor-pointer text-white w-[40px] bg-red-500 p-2 rounded-md "
+              phx-click="delete_photo"
+              data-confirm={
+                if @story.headline && @story.headline.subject == "About me" do
+                  with_locale(@language, fn ->
+                    gettext(
+                      "Are you sure you want to delete your profile photo ? This will hibernate your account until you upload another photo"
+                    )
+                  end)
+                else
+                  with_locale(@language, fn ->
+                    gettext("Are you sure you want to delete this photo ?")
+                  end)
+                end
+              }
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+            </div>
+            <img
+              class="object-cover md:h-200  drop-shadow border md:w-[300px] w-[100%] rounded-lg"
+              src={Photo.get_optimized_photo_to_use(@photo, :normal)}
+            />
+          </div>
         </div>
 
         <.inputs_for :let={photo_form} field={@form[:photo]}>

--- a/lib/animina_web/live/story_live.ex
+++ b/lib/animina_web/live/story_live.ex
@@ -1037,7 +1037,7 @@ defmodule AniminaWeb.StoryLive do
                 if @story.headline && @story.headline.subject == "About me" do
                   with_locale(@language, fn ->
                     gettext(
-                      "Are you sure you want to delete your profile photo ? This will hibernate your account until you upload another photo"
+                      "Are you sure you want to delete your about me photo ? This will hibernate your account until you upload another photo"
                     )
                   end)
                 else

--- a/lib/mix/tasks/seed_demo_system.ex
+++ b/lib/mix/tasks/seed_demo_system.ex
@@ -36,6 +36,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
       raw_seed_data = [
         %{
           unsplash_photo_id: "photo-1531123897727-8f129e1688ce",
+          unsplash_about_me_photo_id: "photo-1524253482453-3fed8d2fe12b",
           gender: "female",
           about_me:
             "I'm a passionate traveler and foodie. I love exploring new cultures and trying out exotic cuisines. When I'm not traveling, you can find me reading a good book or practicing yoga. My ultimate goal is to visit every continent and learn at least one dish from each country I visit. I believe that travel broadens the mind and enriches the soul, and I enjoy sharing my experiences with others through my travel blog.",
@@ -49,6 +50,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1526080652727-5b77f74eacd2",
+          unsplash_about_me_photo_id: "photo-1535713875002-d1d0cf377fde",
           gender: "female",
           about_me:
             "As a software developer by day and a painter by night, I find joy in both logic and creativity. I enjoy hiking on weekends and volunteering at animal shelters. My paintings are often inspired by the beauty I see during my hikes, and I love creating art that captures the essence of nature. Volunteering at animal shelters brings me immense joy, as I believe in giving back to the community and helping animals in need.",
@@ -62,6 +64,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1598897516650-e4dc73d8e417",
+          unsplash_about_me_photo_id: "photo-1582169505937-d7885ebf3bc1",
           gender: "female",
           about_me:
             "Music is my life! I play the guitar and love attending live concerts. I also enjoy baking and often experiment with new dessert recipes. There's something magical about creating music and sharing it with others, and I hope to someday perform in front of a large audience. Baking is my therapy, and I find peace in the process of mixing ingredients and creating delicious treats for my loved ones.",
@@ -75,6 +78,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1536896407451-6e3dd976edd1",
+          unsplash_about_me_photo_id: "photo-1540479859555-17af45c37b3e",
           gender: "female",
           about_me:
             "I'm an avid runner and have completed several marathons. I love the thrill of pushing my limits. In my downtime, I enjoy binge-watching mystery series and gardening. Running has taught me the importance of perseverance and discipline, and it keeps me motivated to achieve my goals. Gardening is my way of connecting with nature and finding tranquility amidst the hustle and bustle of life.",
@@ -88,6 +92,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1499399244875-59ef3e1347e3",
+          unsplash_about_me_photo_id: "photo-1533577116850-9cc66cad8a9b",
           gender: "female",
           about_me:
             "I'm a nature enthusiast and spend most of my free time in the great outdoors. Hiking, camping, and bird watching are some of my favorite activities. I also enjoy photography and capturing the beauty of nature. My dream is to travel to all the national parks and document my journey through photographs and journals. There's something truly magical about being in the wild and experiencing nature in its purest form.",
@@ -101,6 +106,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1484608856193-968d2be4080e",
+          unsplash_about_me_photo_id: "photo-1521305916504-4a1121188589",
           gender: "female",
           about_me:
             "A history buff and a museum lover, I enjoy learning about different cultures and eras. I also love cooking and often host dinner parties for my friends. Exploring ancient ruins and visiting historical landmarks is my way of traveling back in time and understanding the world's rich history. Cooking is my way of expressing creativity, and I find joy in experimenting with different cuisines and flavors.",
@@ -114,6 +120,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1502768040783-423da5fd5fa0",
+          unsplash_about_me_photo_id: "photo-1502768040783-423da5fd5fa0",
           gender: "female",
           about_me:
             "I work as a graphic designer and have a keen eye for detail. I love visiting art galleries and attending creative workshops. My weekends are usually spent cycling around the city. Design is my passion, and I find inspiration in everyday life, whether it's the architecture of buildings or the colors of a sunset. Cycling helps me clear my mind and stay fit while exploring the urban landscape.",
@@ -127,6 +134,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1465406325903-9d93ee82f613",
+          unsplash_about_me_photo_id: "photo-1540206395-68808572332f",
           gender: "female",
           about_me:
             "I'm a fitness trainer and a health nut. I love helping people achieve their fitness goals. When I'm not at the gym, I enjoy reading about nutrition and wellness. Fitness is my way of life, and I believe in the power of a healthy body and mind. I enjoy sharing my knowledge with others and motivating them to lead healthier, happier lives. In my spare time, I experiment with new healthy recipes and stay updated with the latest in fitness science.",
@@ -140,6 +148,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1542596594-649edbc13630",
+          unsplash_about_me_photo_id: "photo-1542596594-649edbc13630",
           gender: "female",
           about_me:
             "I have a passion for fashion and work as a stylist. I enjoy experimenting with different looks and keeping up with the latest trends. In my spare time, I like to unwind with a good movie or a night out with friends. Fashion is not just a career for me; it's a way of expressing myself and making a statement. I love helping people find their style and feel confident in their own skin.",
@@ -153,6 +162,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1520466809213-7b9a56adcd45",
+          unsplash_about_me_photo_id: "photo-1520466809213-7b9a56adcd45",
           gender: "female",
           about_me:
             "I'm a scientist with a love for the stars. Astronomy fascinates me, and I spend many nights stargazing. I also enjoy playing chess and solving puzzles. Science is my calling, and I love unraveling the mysteries of the universe. Stargazing is my way of connecting with the cosmos and pondering our place in the vast expanse. Chess and puzzles keep my mind sharp and challenge me to think critically.",
@@ -166,6 +176,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1580489944761-15a19d654956",
+          unsplash_about_me_photo_id: "photo-1580489944761-15a19d654956",
           gender: "female",
           about_me:
             "I run a small bakery and love creating new recipes. My dream is to open a chain of bakeries someday. In my free time, I enjoy knitting and reading romantic novels. Baking is my passion, and I find joy in seeing people smile when they taste my creations. Knitting helps me relax, and I love crafting handmade gifts for my loved ones. Reading romantic novels transports me to a world of love and adventure, fueling my creativity.",
@@ -179,6 +190,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1567532939604-b6b5b0db2604",
+          unsplash_about_me_photo_id: "photo-1567532939604-b6b5b0db2604",
           gender: "female",
           about_me:
             "As a teacher, I find joy in shaping young minds. I love working with children and making learning fun. My hobbies include playing the piano and gardening. Teaching is my calling, and I believe in the power of education to change lives. I strive to create a positive and engaging learning environment for my students. Playing the piano helps me unwind, and gardening allows me to nurture life and witness the beauty of growth.",
@@ -192,6 +204,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1505640070685-2a70292000ff",
+          unsplash_about_me_photo_id: "photo-1505640070685-2a70292000ff",
           gender: "male",
           about_me:
             "As an engineer, I find satisfaction in solving complex problems and bringing innovative ideas to life. I enjoy working with technology and constantly learning about new advancements. My hobbies include cycling and woodworking. Engineering is my passion, and I believe in the impact of technology on improving lives. I strive to create efficient and sustainable solutions in my projects. Cycling helps me stay fit and clear my mind, while woodworking allows me to create tangible and functional pieces.",
@@ -205,6 +218,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1557862921-37829c790f19",
+          unsplash_about_me_photo_id: "photo-1557862921-37829c790f19",
           gender: "male",
           about_me:
             "As a doctor, I am dedicated to improving the health and well-being of my patients. I enjoy the challenges and rewards that come with the medical profession. My hobbies include running and cooking. Medicine is not just a career for me, but a calling. I believe in providing compassionate care and staying updated with the latest medical advancements. Running helps me stay fit and focused, while cooking allows me to relax and experiment with new recipes.",
@@ -218,6 +232,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1702449269565-8bbe32972f65",
+          unsplash_about_me_photo_id: "photo-1702449269565-8bbe32972f65",
           gender: "male",
           about_me:
             "As a software developer, I thrive on the creativity and logic required to build innovative solutions. I enjoy coding, learning new programming languages, and keeping up with technology trends. My hobbies include playing chess and hiking. Software development allows me to turn ideas into reality, and I believe in the power of technology to solve real-world problems. Playing chess sharpens my strategic thinking, while hiking provides me with an escape into nature and a chance to recharge.",
@@ -231,6 +246,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1700856417754-cb66c909f4d7",
+          unsplash_about_me_photo_id: "photo-1700856417754-cb66c909f4d7",
           gender: "male",
           about_me:
             "As a chef, I am passionate about creating delicious and innovative dishes. I enjoy experimenting with flavors and ingredients to surprise and delight my guests. My hobbies include painting and cycling. Cooking is an art for me, and I believe in the joy that good food can bring to people's lives. Painting allows me to express my creativity, while cycling helps me stay active and explore new places.",
@@ -244,6 +260,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1627837661889-6fc9434e12f6",
+          unsplash_about_me_photo_id: "photo-1627837661889-6fc9434e12f6",
           gender: "male",
           about_me:
             "As a journalist, I am dedicated to uncovering the truth and telling compelling stories. I enjoy investigating important issues and giving a voice to those who are often unheard. My hobbies include reading and photography. Journalism is my way of making a difference in the world, and I believe in the power of a well-told story to inspire change. Reading helps me stay informed, while photography allows me to capture moments and tell visual stories.",
@@ -257,6 +274,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1677759337999-ceae7a0a5faa",
+          unsplash_about_me_photo_id: "photo-1677759337999-ceae7a0a5faa",
           gender: "male",
           about_me:
             "As a musician, I find joy in creating and performing music that resonates with people. I enjoy exploring different genres and collaborating with other artists. My hobbies include traveling and learning new languages. Music is my universal language, and I believe in its ability to bring people together. Traveling inspires my creativity, while learning languages helps me connect with diverse cultures and audiences.",
@@ -270,6 +288,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1707139743543-590aeb0437d8",
+          unsplash_about_me_photo_id: "photo-1707139743543-590aeb0437d8",
           gender: "male",
           about_me:
             "As an architect, I am passionate about designing spaces that are both functional and beautiful. I enjoy the challenge of bringing creative visions to life and improving the environments where people live and work. My hobbies include photography and hiking. Architecture allows me to blend art and science, and I believe in the transformative power of good design. Photography helps me see the world from different perspectives, while hiking provides inspiration from nature.",
@@ -283,6 +302,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1506794778202-cad84cf45f1d",
+          unsplash_about_me_photo_id: "photo-1506794778202-cad84cf45f1d",
           gender: "male",
           about_me:
             "As a scientist, I am driven by curiosity and the desire to understand the natural world. I enjoy conducting experiments, analyzing data, and discovering new phenomena. My hobbies include stargazing and playing the guitar. Science is my way of making sense of the universe, and I believe in the importance of research and innovation. Stargazing fuels my sense of wonder, while playing the guitar helps me relax and express myself creatively.",
@@ -296,6 +316,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1531891570158-e71b35a485bc",
+          unsplash_about_me_photo_id: "photo-1531891570158-e71b35a485bc",
           gender: "male",
           about_me:
             "As a pilot, I find exhilaration in soaring through the skies and experiencing the world from above. I enjoy navigating complex airspaces and ensuring the safety of my passengers. My hobbies include skydiving and scuba diving. Aviation is my passion, and I believe in the freedom and adventure that flying brings. Skydiving pushes my limits, while scuba diving allows me to explore the mysteries of the underwater world.",
@@ -309,6 +330,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1582015752624-e8b1c75e3711",
+          unsplash_about_me_photo_id: "photo-1582015752624-e8b1c75e3711",
           gender: "male",
           about_me:
             "As a historian, I am fascinated by the stories and events that have shaped our world. I enjoy researching, writing, and teaching about history. My hobbies include visiting museums and collecting rare books. History is my passion, and I believe in preserving the past to understand the present and future. Visiting museums enriches my knowledge, while collecting rare books connects me to the historical periods I study.",
@@ -322,6 +344,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1525393839361-867d646aea41",
+          unsplash_about_me_photo_id: "photo-1525393839361-867d646aea41",
           gender: "male",
           about_me:
             "As a wildlife photographer, I am passionate about capturing the beauty and diversity of the natural world. I enjoy traveling to remote locations and patiently waiting for the perfect shot. My hobbies include birdwatching and hiking. Photography allows me to share the wonders of nature with others, and I believe in the importance of conservation. Birdwatching helps me appreciate the avian world, while hiking takes me to breathtaking landscapes.",
@@ -335,6 +358,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1614647444531-ac308ea848eb",
+          unsplash_about_me_photo_id: "photo-1614647444531-ac308ea848eb",
           gender: "male",
           about_me:
             "As a marine biologist, I am dedicated to studying and protecting marine life. I enjoy conducting research, diving, and exploring underwater ecosystems. My hobbies include sailing and underwater photography. Marine biology is my calling, and I believe in the importance of preserving our oceans. Sailing connects me to the marine environment, while underwater photography allows me to document the incredible diversity beneath the waves.",
@@ -348,6 +372,7 @@ if Enum.member?([:dev, :test], Mix.env()) do
         },
         %{
           unsplash_photo_id: "photo-1500648767791-00dcc994a43e",
+          unsplash_about_me_photo_id: "photo-1500648767791-00dcc994a43e",
           gender: "male",
           about_me:
             "As a paramedic, I am committed to providing emergency medical care and saving lives. I enjoy the fast-paced nature of my job and the opportunity to help people in critical situations. My hobbies include mountain biking and playing the drums. Being a paramedic is my way of making a difference, and I believe in the importance of quick and compassionate care. Mountain biking keeps me fit and adventurous, while playing the drums helps me unwind and express my rhythm.",
@@ -418,8 +443,11 @@ if Enum.member?([:dev, :test], Mix.env()) do
           position: 1
         })
 
+      about_me_photo =
+        download_photo(seed_data.unsplash_about_me_photo_id, "#{Faker.UUID.v4()}.png")
+
       # create about me story photo
-      Photo.create!(Map.merge(photo, %{user_id: user.id, story_id: story.id}))
+      Photo.create!(Map.merge(about_me_photo, %{user_id: user.id, story_id: story.id}))
 
       unused_photos = all_photos()
 

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr "10 Sekunden"
 msgid "ANIMINA dashboard - "
 msgstr "ANIMINA-Dashboard - "
 
-#: lib/animina_web/live/story_live.ex:778
+#: lib/animina_web/live/story_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "About me"
 msgstr "Über mich"
@@ -144,7 +144,7 @@ msgid "By"
 msgstr "Von"
 
 #: lib/animina_web/live/profile_photo_live.ex:273
-#: lib/animina_web/live/story_live.ex:1099
+#: lib/animina_web/live/story_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -165,7 +165,7 @@ msgstr "Profil-Sichtbarkeit ändern"
 msgid "Change Visibility"
 msgstr "Sichtbarkeit ändern"
 
-#: lib/animina_web/live/story_live.ex:816
+#: lib/animina_web/live/story_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Characters: "
 msgstr "Zeichen: "
@@ -202,9 +202,9 @@ msgstr "Wählen Sie bis zu %{number_of_flags} Flags, die Ihr Partner haben soll.
 
 #: lib/animina_web/live/post_live.ex:258
 #: lib/animina_web/live/post_live.ex:287
-#: lib/animina_web/live/story_live.ex:810
-#: lib/animina_web/live/story_live.ex:850
-#: lib/animina_web/live/story_live.ex:880
+#: lib/animina_web/live/story_live.ex:822
+#: lib/animina_web/live/story_live.ex:862
+#: lib/animina_web/live/story_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "Content"
 msgstr "Inhalt"
@@ -478,9 +478,9 @@ msgstr "Zugang gewähren"
 msgid "Given"
 msgstr "Gegeben"
 
-#: lib/animina_web/live/story_live.ex:742
-#: lib/animina_web/live/story_live.ex:769
-#: lib/animina_web/live/story_live.ex:797
+#: lib/animina_web/live/story_live.ex:754
+#: lib/animina_web/live/story_live.ex:781
+#: lib/animina_web/live/story_live.ex:809
 #, elixir-autogen, elixir-format
 msgid "Headline"
 msgstr "Überschrift"
@@ -556,8 +556,8 @@ msgstr "Letzte 7 Tage"
 msgid "Latest Chat"
 msgstr "Letzter Chat"
 
-#: lib/animina_web/live/story_live.ex:964
-#: lib/animina_web/live/story_live.ex:972
+#: lib/animina_web/live/story_live.ex:976
+#: lib/animina_web/live/story_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Lengthen Story"
 msgstr "Story verlängern"
@@ -600,8 +600,8 @@ msgstr "Am häufigsten besuchte Profile"
 msgid "Lost connection to server!"
 msgstr "Verbindung zum Server verloren!"
 
-#: lib/animina_web/live/story_live.ex:924
-#: lib/animina_web/live/story_live.ex:932
+#: lib/animina_web/live/story_live.ex:936
+#: lib/animina_web/live/story_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "Make Funnier"
 msgstr "Witziger machen"
@@ -759,8 +759,8 @@ msgstr "Ausstehende Überprüfung"
 msgid "Permanently delete your account and all data , this action is irreversible."
 msgstr "Löschen Sie Ihr Konto und alle Daten dauerhaft, diese Aktion ist nicht rückgängig zu machen."
 
-#: lib/animina_web/live/story_live.ex:1017
-#: lib/animina_web/live/story_live.ex:1035
+#: lib/animina_web/live/story_live.ex:1029
+#: lib/animina_web/live/story_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr "Foto"
@@ -945,8 +945,8 @@ msgstr "Verbleibende Sekunden"
 msgid "Select And Change the visibility of your profile"
 msgstr "Wählen und ändern Sie die Sichtbarkeit Ihres Profils"
 
-#: lib/animina_web/live/story_live.ex:762
-#: lib/animina_web/live/story_live.ex:790
+#: lib/animina_web/live/story_live.ex:774
+#: lib/animina_web/live/story_live.ex:802
 #, elixir-autogen, elixir-format
 msgid "Select a headline"
 msgstr "Eine Überschrift auswählen"
@@ -981,8 +981,8 @@ msgstr "Link zum Zurücksetzen des Passworts senden"
 msgid "Server problem!"
 msgstr "Serverproblem!"
 
-#: lib/animina_web/live/story_live.ex:984
-#: lib/animina_web/live/story_live.ex:992
+#: lib/animina_web/live/story_live.ex:996
+#: lib/animina_web/live/story_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Shorten Story"
 msgstr "Story verkürzen"
@@ -1013,8 +1013,8 @@ msgstr "Angemeldet als"
 msgid "Something went wrong adding your flags"
 msgstr "Beim Hinzufügen Ihrer Flags ist ein Fehler aufgetreten"
 
-#: lib/animina_web/live/profile_photo_live.ex:341
-#: lib/animina_web/live/story_live.ex:1161
+#: lib/animina_web/live/profile_photo_live.ex:366
+#: lib/animina_web/live/story_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Something went wrong uploading your photo. Try again"
 msgstr "Beim Hochladen Ihres Fotos ist ein Fehler aufgetreten. Versuchen Sie es erneut"
@@ -1081,8 +1081,8 @@ msgstr "Titel"
 msgid "To report an account is a serious act. The account will be deactivated right away and will be investigated by our team. Please tell us why you report the account."
 msgstr "Ein Konto zu melden ist eine ernste Angelegenheit. Das Konto wird sofort deaktiviert und von unserem Team untersucht. Bitte teilen Sie uns mit, warum Sie das Konto melden."
 
-#: lib/animina_web/live/profile_photo_live.ex:330
-#: lib/animina_web/live/story_live.ex:1150
+#: lib/animina_web/live/profile_photo_live.ex:355
+#: lib/animina_web/live/story_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Too large"
 msgstr "Zu groß"
@@ -1117,7 +1117,7 @@ msgstr "Aktualisieren Sie Ihr Avatar-Foto für Ihr Konto"
 msgid "Update your profile photo & drop your photo file JPG, JPEG, PNG"
 msgstr "Aktualisieren Sie Ihr Profilfoto und ziehen Sie Ihre Fotodatei JPG, JPEG, PNG hierher"
 
-#: lib/animina_web/live/profile_photo_live.ex:313
+#: lib/animina_web/live/profile_photo_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr "Hochladen"
@@ -1133,12 +1133,12 @@ msgid "Upload an avatar photo for your account"
 msgstr "Ein Avatar-Foto für Ihr Konto hochladen"
 
 #: lib/animina_web/live/profile_photo_live.ex:238
-#: lib/animina_web/live/story_live.ex:1069
+#: lib/animina_web/live/story_live.ex:1112
 #, elixir-autogen, elixir-format
 msgid "Upload or drag & drop your photo file JPG, JPEG, PNG"
 msgstr "Laden Sie Ihre Fotodatei JPG, JPEG, PNG hoch oder ziehen Sie sie per Drag & Drop hierher"
 
-#: lib/animina_web/live/profile_photo_live.ex:314
+#: lib/animina_web/live/profile_photo_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Uploading..."
 msgstr "Wird hochgeladen..."
@@ -1163,8 +1163,8 @@ msgstr "Verwenden Sie normalen Text oder das Markdown-Format, um Ihr internes Me
 msgid "Use normal text or the Markdown format to write your post. You can use **bold**, *italic*, ~line-through~, [links](https://example.com) and more. Each post can be up to 8,192 characters long. Please do write multiple posts to share your thoughts."
 msgstr "Verwenden Sie normalen Text oder das Markdown-Format, um Ihren Beitrag zu schreiben. Sie können **fett**, *kursiv*, ~durchgestrichen~, [Links](https://example.com) und mehr verwenden. Jeder Beitrag kann bis zu 8.192 Zeichen lang sein. Schreiben Sie bitte mehrere Beiträge, um Ihre Gedanken zu teilen."
 
-#: lib/animina_web/live/story_live.ex:836
-#: lib/animina_web/live/story_live.ex:866
+#: lib/animina_web/live/story_live.ex:848
+#: lib/animina_web/live/story_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "Use normal text or the Markdown format to write your story. You can use **bold**, *italic*, ~line-through~, [links](https://example.com) and more. Each story can be up to 1,024 characters long. Please do write multiple stories to tell potential partners more about yourself."
 msgstr "Verwenden Sie normalen Text oder das Markdown-Format, um Ihre Story zu schreiben. Sie können **fett**, *kursiv*, ~durchgestrichen~, [Links](https://example.com) und mehr verwenden. Jede Story kann bis zu 1.024 Zeichen lang sein. Schreiben Sie bitte mehrere Storys, um potenziellen Partnern mehr über sich zu erzählen."
@@ -1251,14 +1251,14 @@ msgstr "Internes Memo schreiben"
 msgid "You can delete your account here but you have to wait "
 msgstr "Sie können Ihr Konto hier löschen, aber Sie müssen warten "
 
-#: lib/animina_web/live/profile_photo_live.ex:333
-#: lib/animina_web/live/story_live.ex:1153
+#: lib/animina_web/live/profile_photo_live.ex:358
+#: lib/animina_web/live/story_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "You have selected an unacceptable file type"
 msgstr "Sie haben einen unzulässigen Dateityp ausgewählt"
 
-#: lib/animina_web/live/profile_photo_live.ex:336
-#: lib/animina_web/live/story_live.ex:1156
+#: lib/animina_web/live/profile_photo_live.ex:361
+#: lib/animina_web/live/story_live.ex:1199
 #, elixir-autogen, elixir-format
 msgid "You have selected too many files"
 msgstr "Sie haben zu viele Dateien ausgewählt"
@@ -1424,17 +1424,17 @@ msgstr "Unsere interne KI wird mit diesem Text gefüttert. Bitte einen Moment wa
 
 #: lib/animina_web/live/story_live.ex:30
 #: lib/animina_web/live/story_live.ex:75
-#: lib/animina_web/live/story_live.ex:912
+#: lib/animina_web/live/story_live.ex:924
 #, elixir-autogen, elixir-format
 msgid "Fix spelling and grammar errors"
 msgstr "Rechtschreib- und Grammatikfehler beheben"
 
-#: lib/animina_web/live/story_live.ex:904
+#: lib/animina_web/live/story_live.ex:916
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Fix spelling and grammar errors."
 msgstr "Rechtschreib- und Grammatikfehler beheben"
 
-#: lib/animina_web/live/story_live.ex:1008
+#: lib/animina_web/live/story_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Generate story"
 msgstr "Story generieren"
@@ -1444,8 +1444,8 @@ msgstr "Story generieren"
 msgid "Language switched successfully"
 msgstr "Sprache erfolgreich umgeschaltet"
 
-#: lib/animina_web/live/story_live.ex:944
-#: lib/animina_web/live/story_live.ex:952
+#: lib/animina_web/live/story_live.ex:956
+#: lib/animina_web/live/story_live.ex:964
 #, elixir-autogen, elixir-format, fuzzy
 msgid "More Exciting"
 msgstr "Spannender machen"
@@ -1460,7 +1460,7 @@ msgstr "Neue Nachrichten"
 msgid "No Unread Messages"
 msgstr "Keine ungelesenen Nachrichten"
 
-#: lib/animina_web/live/story_live.ex:889
+#: lib/animina_web/live/story_live.ex:901
 #, elixir-autogen, elixir-format
 msgid "Optimize a Story"
 msgstr "Eine Story optimieren"
@@ -1490,7 +1490,7 @@ msgstr "Benutzer melden"
 msgid "Report reviewed successfully."
 msgstr "Bericht erfolgreich überprüft."
 
-#: lib/animina_web/live/story_live.ex:1124
+#: lib/animina_web/live/story_live.ex:1167
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr "Wird gespeichert..."
@@ -1500,7 +1500,7 @@ msgstr "Wird gespeichert..."
 msgid "To activate your profile you have to have at least an about me story and a profile picture uploaded. A story can contain just a photo, just a text or both combined. You can add, edit and delete stories anytime. With stories you present yourself to others. You have more success with at least three of them in your profile."
 msgstr "Um Ihr Profil zu aktivieren, müssen Sie mindestens eine Story haben. Eine Story kann nur ein Foto, nur einen Text oder beides enthalten. Sie können Stories jederzeit hinzufügen, bearbeiten und löschen. Mit Stories präsentieren Sie sich anderen. Sie haben mehr Erfolg, wenn Sie mindestens drei davon in Ihrem Profil haben."
 
-#: lib/animina_web/live/story_live.ex:1031
+#: lib/animina_web/live/story_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "Update Photo"
 msgstr "Foto aktualisieren"
@@ -1651,3 +1651,24 @@ msgstr "Besucht"
 #, elixir-autogen, elixir-format
 msgid "page to activate it again."
 msgstr "Seite, um es wieder zu aktivieren."
+
+#: lib/animina_web/live/story_live.ex:1045
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Are you sure you want to delete this photo ?"
+msgstr "Sind Sie sicher, dass Sie Ihr Konto löschen möchten?"
+
+
+#: lib/animina_web/live/story_live.ex:1039
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete your about me photo ? This will hibernate your account until you upload another photo"
+msgstr "Möchten Sie Ihr 'Über mich'-Foto wirklich löschen? Ihr Konto wird pausiert, bis Sie ein neues Foto hochladen."
+
+#: lib/animina_web/live/profile_photo_live.ex:310
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete your profile photo ? This will hibernate your account until you upload another photo"
+msgstr "Möchten Sie Ihr Profilfoto wirklich löschen? Ihr Konto wird pausiert, bis Sie ein neues Foto hochladen."
+
+#: lib/animina_web/live/story_live.ex:475
+#, elixir-autogen, elixir-format
+msgid "Photo removed successfully !"
+msgstr "Foto erfolgreich entfernt!"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -21,7 +21,7 @@ msgstr ""
 msgid "ANIMINA dashboard - "
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:778
+#: lib/animina_web/live/story_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "About me"
 msgstr ""
@@ -144,7 +144,7 @@ msgid "By"
 msgstr ""
 
 #: lib/animina_web/live/profile_photo_live.ex:273
-#: lib/animina_web/live/story_live.ex:1099
+#: lib/animina_web/live/story_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Change Visibility"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:816
+#: lib/animina_web/live/story_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Characters: "
 msgstr ""
@@ -202,9 +202,9 @@ msgstr ""
 
 #: lib/animina_web/live/post_live.ex:258
 #: lib/animina_web/live/post_live.ex:287
-#: lib/animina_web/live/story_live.ex:810
-#: lib/animina_web/live/story_live.ex:850
-#: lib/animina_web/live/story_live.ex:880
+#: lib/animina_web/live/story_live.ex:822
+#: lib/animina_web/live/story_live.ex:862
+#: lib/animina_web/live/story_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "Content"
 msgstr ""
@@ -478,9 +478,9 @@ msgstr ""
 msgid "Given"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:742
-#: lib/animina_web/live/story_live.ex:769
-#: lib/animina_web/live/story_live.ex:797
+#: lib/animina_web/live/story_live.ex:754
+#: lib/animina_web/live/story_live.ex:781
+#: lib/animina_web/live/story_live.ex:809
 #, elixir-autogen, elixir-format
 msgid "Headline"
 msgstr ""
@@ -556,8 +556,8 @@ msgstr ""
 msgid "Latest Chat"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:964
-#: lib/animina_web/live/story_live.ex:972
+#: lib/animina_web/live/story_live.ex:976
+#: lib/animina_web/live/story_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Lengthen Story"
 msgstr ""
@@ -600,8 +600,8 @@ msgstr ""
 msgid "Lost connection to server!"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:924
-#: lib/animina_web/live/story_live.ex:932
+#: lib/animina_web/live/story_live.ex:936
+#: lib/animina_web/live/story_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "Make Funnier"
 msgstr ""
@@ -759,8 +759,8 @@ msgstr ""
 msgid "Permanently delete your account and all data , this action is irreversible."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1017
-#: lib/animina_web/live/story_live.ex:1035
+#: lib/animina_web/live/story_live.ex:1029
+#: lib/animina_web/live/story_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -945,8 +945,8 @@ msgstr ""
 msgid "Select And Change the visibility of your profile"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:762
-#: lib/animina_web/live/story_live.ex:790
+#: lib/animina_web/live/story_live.ex:774
+#: lib/animina_web/live/story_live.ex:802
 #, elixir-autogen, elixir-format
 msgid "Select a headline"
 msgstr ""
@@ -981,8 +981,8 @@ msgstr ""
 msgid "Server problem!"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:984
-#: lib/animina_web/live/story_live.ex:992
+#: lib/animina_web/live/story_live.ex:996
+#: lib/animina_web/live/story_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Shorten Story"
 msgstr ""
@@ -1013,8 +1013,8 @@ msgstr ""
 msgid "Something went wrong adding your flags"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:341
-#: lib/animina_web/live/story_live.ex:1161
+#: lib/animina_web/live/profile_photo_live.ex:366
+#: lib/animina_web/live/story_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Something went wrong uploading your photo. Try again"
 msgstr ""
@@ -1081,8 +1081,8 @@ msgstr ""
 msgid "To report an account is a serious act. The account will be deactivated right away and will be investigated by our team. Please tell us why you report the account."
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:330
-#: lib/animina_web/live/story_live.ex:1150
+#: lib/animina_web/live/profile_photo_live.ex:355
+#: lib/animina_web/live/story_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Too large"
 msgstr ""
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "Update your profile photo & drop your photo file JPG, JPEG, PNG"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:313
+#: lib/animina_web/live/profile_photo_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
@@ -1133,12 +1133,12 @@ msgid "Upload an avatar photo for your account"
 msgstr ""
 
 #: lib/animina_web/live/profile_photo_live.ex:238
-#: lib/animina_web/live/story_live.ex:1069
+#: lib/animina_web/live/story_live.ex:1112
 #, elixir-autogen, elixir-format
 msgid "Upload or drag & drop your photo file JPG, JPEG, PNG"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:314
+#: lib/animina_web/live/profile_photo_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Uploading..."
 msgstr ""
@@ -1163,8 +1163,8 @@ msgstr ""
 msgid "Use normal text or the Markdown format to write your post. You can use **bold**, *italic*, ~line-through~, [links](https://example.com) and more. Each post can be up to 8,192 characters long. Please do write multiple posts to share your thoughts."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:836
-#: lib/animina_web/live/story_live.ex:866
+#: lib/animina_web/live/story_live.ex:848
+#: lib/animina_web/live/story_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "Use normal text or the Markdown format to write your story. You can use **bold**, *italic*, ~line-through~, [links](https://example.com) and more. Each story can be up to 1,024 characters long. Please do write multiple stories to tell potential partners more about yourself."
 msgstr ""
@@ -1251,14 +1251,14 @@ msgstr ""
 msgid "You can delete your account here but you have to wait "
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:333
-#: lib/animina_web/live/story_live.ex:1153
+#: lib/animina_web/live/profile_photo_live.ex:358
+#: lib/animina_web/live/story_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "You have selected an unacceptable file type"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:336
-#: lib/animina_web/live/story_live.ex:1156
+#: lib/animina_web/live/profile_photo_live.ex:361
+#: lib/animina_web/live/story_live.ex:1199
 #, elixir-autogen, elixir-format
 msgid "You have selected too many files"
 msgstr ""
@@ -1424,17 +1424,17 @@ msgstr ""
 
 #: lib/animina_web/live/story_live.ex:30
 #: lib/animina_web/live/story_live.ex:75
-#: lib/animina_web/live/story_live.ex:912
+#: lib/animina_web/live/story_live.ex:924
 #, elixir-autogen, elixir-format
 msgid "Fix spelling and grammar errors"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:904
+#: lib/animina_web/live/story_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "Fix spelling and grammar errors."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1008
+#: lib/animina_web/live/story_live.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Generate story"
 msgstr ""
@@ -1444,8 +1444,8 @@ msgstr ""
 msgid "Language switched successfully"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:944
-#: lib/animina_web/live/story_live.ex:952
+#: lib/animina_web/live/story_live.ex:956
+#: lib/animina_web/live/story_live.ex:964
 #, elixir-autogen, elixir-format
 msgid "More Exciting"
 msgstr ""
@@ -1460,7 +1460,7 @@ msgstr ""
 msgid "No Unread Messages"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:889
+#: lib/animina_web/live/story_live.ex:901
 #, elixir-autogen, elixir-format
 msgid "Optimize a Story"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Report reviewed successfully."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1124
+#: lib/animina_web/live/story_live.ex:1167
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr ""
@@ -1500,7 +1500,7 @@ msgstr ""
 msgid "To activate your profile you have to have at least an about me story and a profile picture uploaded. A story can contain just a photo, just a text or both combined. You can add, edit and delete stories anytime. With stories you present yourself to others. You have more success with at least three of them in your profile."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1031
+#: lib/animina_web/live/story_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "Update Photo"
 msgstr ""
@@ -1650,4 +1650,24 @@ msgstr ""
 #: lib/animina_web/components/top_navigation_components.ex:456
 #, elixir-autogen, elixir-format
 msgid "page to activate it again."
+msgstr ""
+
+#: lib/animina_web/live/story_live.ex:1045
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete this photo ?"
+msgstr ""
+
+#: lib/animina_web/live/story_live.ex:1039
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete your about me photo ? This will hibernate your account until you upload another photo"
+msgstr ""
+
+#: lib/animina_web/live/profile_photo_live.ex:310
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete your profile photo ? This will hibernate your account until you upload another photo"
+msgstr ""
+
+#: lib/animina_web/live/story_live.ex:475
+#, elixir-autogen, elixir-format
+msgid "Photo removed successfully !"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -21,7 +21,7 @@ msgstr ""
 msgid "ANIMINA dashboard - "
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:778
+#: lib/animina_web/live/story_live.ex:790
 #, elixir-autogen, elixir-format
 msgid "About me"
 msgstr ""
@@ -144,7 +144,7 @@ msgid "By"
 msgstr ""
 
 #: lib/animina_web/live/profile_photo_live.ex:273
-#: lib/animina_web/live/story_live.ex:1099
+#: lib/animina_web/live/story_live.ex:1142
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -165,7 +165,7 @@ msgstr ""
 msgid "Change Visibility"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:816
+#: lib/animina_web/live/story_live.ex:828
 #, elixir-autogen, elixir-format
 msgid "Characters: "
 msgstr ""
@@ -202,9 +202,9 @@ msgstr ""
 
 #: lib/animina_web/live/post_live.ex:258
 #: lib/animina_web/live/post_live.ex:287
-#: lib/animina_web/live/story_live.ex:810
-#: lib/animina_web/live/story_live.ex:850
-#: lib/animina_web/live/story_live.ex:880
+#: lib/animina_web/live/story_live.ex:822
+#: lib/animina_web/live/story_live.ex:862
+#: lib/animina_web/live/story_live.ex:892
 #, elixir-autogen, elixir-format
 msgid "Content"
 msgstr ""
@@ -478,9 +478,9 @@ msgstr ""
 msgid "Given"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:742
-#: lib/animina_web/live/story_live.ex:769
-#: lib/animina_web/live/story_live.ex:797
+#: lib/animina_web/live/story_live.ex:754
+#: lib/animina_web/live/story_live.ex:781
+#: lib/animina_web/live/story_live.ex:809
 #, elixir-autogen, elixir-format
 msgid "Headline"
 msgstr ""
@@ -556,8 +556,8 @@ msgstr ""
 msgid "Latest Chat"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:964
-#: lib/animina_web/live/story_live.ex:972
+#: lib/animina_web/live/story_live.ex:976
+#: lib/animina_web/live/story_live.ex:984
 #, elixir-autogen, elixir-format
 msgid "Lengthen Story"
 msgstr ""
@@ -600,8 +600,8 @@ msgstr ""
 msgid "Lost connection to server!"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:924
-#: lib/animina_web/live/story_live.ex:932
+#: lib/animina_web/live/story_live.ex:936
+#: lib/animina_web/live/story_live.ex:944
 #, elixir-autogen, elixir-format
 msgid "Make Funnier"
 msgstr ""
@@ -759,8 +759,8 @@ msgstr ""
 msgid "Permanently delete your account and all data , this action is irreversible."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1017
-#: lib/animina_web/live/story_live.ex:1035
+#: lib/animina_web/live/story_live.ex:1029
+#: lib/animina_web/live/story_live.ex:1078
 #, elixir-autogen, elixir-format
 msgid "Photo"
 msgstr ""
@@ -945,8 +945,8 @@ msgstr ""
 msgid "Select And Change the visibility of your profile"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:762
-#: lib/animina_web/live/story_live.ex:790
+#: lib/animina_web/live/story_live.ex:774
+#: lib/animina_web/live/story_live.ex:802
 #, elixir-autogen, elixir-format
 msgid "Select a headline"
 msgstr ""
@@ -981,8 +981,8 @@ msgstr ""
 msgid "Server problem!"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:984
-#: lib/animina_web/live/story_live.ex:992
+#: lib/animina_web/live/story_live.ex:996
+#: lib/animina_web/live/story_live.ex:1004
 #, elixir-autogen, elixir-format
 msgid "Shorten Story"
 msgstr ""
@@ -1013,8 +1013,8 @@ msgstr ""
 msgid "Something went wrong adding your flags"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:341
-#: lib/animina_web/live/story_live.ex:1161
+#: lib/animina_web/live/profile_photo_live.ex:366
+#: lib/animina_web/live/story_live.ex:1204
 #, elixir-autogen, elixir-format
 msgid "Something went wrong uploading your photo. Try again"
 msgstr ""
@@ -1081,8 +1081,8 @@ msgstr ""
 msgid "To report an account is a serious act. The account will be deactivated right away and will be investigated by our team. Please tell us why you report the account."
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:330
-#: lib/animina_web/live/story_live.ex:1150
+#: lib/animina_web/live/profile_photo_live.ex:355
+#: lib/animina_web/live/story_live.ex:1193
 #, elixir-autogen, elixir-format
 msgid "Too large"
 msgstr ""
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "Update your profile photo & drop your photo file JPG, JPEG, PNG"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:313
+#: lib/animina_web/live/profile_photo_live.ex:338
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
@@ -1133,12 +1133,12 @@ msgid "Upload an avatar photo for your account"
 msgstr ""
 
 #: lib/animina_web/live/profile_photo_live.ex:238
-#: lib/animina_web/live/story_live.ex:1069
+#: lib/animina_web/live/story_live.ex:1112
 #, elixir-autogen, elixir-format
 msgid "Upload or drag & drop your photo file JPG, JPEG, PNG"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:314
+#: lib/animina_web/live/profile_photo_live.ex:339
 #, elixir-autogen, elixir-format
 msgid "Uploading..."
 msgstr ""
@@ -1163,8 +1163,8 @@ msgstr ""
 msgid "Use normal text or the Markdown format to write your post. You can use **bold**, *italic*, ~line-through~, [links](https://example.com) and more. Each post can be up to 8,192 characters long. Please do write multiple posts to share your thoughts."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:836
-#: lib/animina_web/live/story_live.ex:866
+#: lib/animina_web/live/story_live.ex:848
+#: lib/animina_web/live/story_live.ex:878
 #, elixir-autogen, elixir-format
 msgid "Use normal text or the Markdown format to write your story. You can use **bold**, *italic*, ~line-through~, [links](https://example.com) and more. Each story can be up to 1,024 characters long. Please do write multiple stories to tell potential partners more about yourself."
 msgstr ""
@@ -1251,14 +1251,14 @@ msgstr ""
 msgid "You can delete your account here but you have to wait "
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:333
-#: lib/animina_web/live/story_live.ex:1153
+#: lib/animina_web/live/profile_photo_live.ex:358
+#: lib/animina_web/live/story_live.ex:1196
 #, elixir-autogen, elixir-format
 msgid "You have selected an unacceptable file type"
 msgstr ""
 
-#: lib/animina_web/live/profile_photo_live.ex:336
-#: lib/animina_web/live/story_live.ex:1156
+#: lib/animina_web/live/profile_photo_live.ex:361
+#: lib/animina_web/live/story_live.ex:1199
 #, elixir-autogen, elixir-format
 msgid "You have selected too many files"
 msgstr ""
@@ -1424,17 +1424,17 @@ msgstr ""
 
 #: lib/animina_web/live/story_live.ex:30
 #: lib/animina_web/live/story_live.ex:75
-#: lib/animina_web/live/story_live.ex:912
+#: lib/animina_web/live/story_live.ex:924
 #, elixir-autogen, elixir-format
 msgid "Fix spelling and grammar errors"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:904
+#: lib/animina_web/live/story_live.ex:916
 #, elixir-autogen, elixir-format
 msgid "Fix spelling and grammar errors."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1008
+#: lib/animina_web/live/story_live.ex:1020
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Generate story"
 msgstr ""
@@ -1444,8 +1444,8 @@ msgstr ""
 msgid "Language switched successfully"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:944
-#: lib/animina_web/live/story_live.ex:952
+#: lib/animina_web/live/story_live.ex:956
+#: lib/animina_web/live/story_live.ex:964
 #, elixir-autogen, elixir-format, fuzzy
 msgid "More Exciting"
 msgstr ""
@@ -1460,7 +1460,7 @@ msgstr ""
 msgid "No Unread Messages"
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:889
+#: lib/animina_web/live/story_live.ex:901
 #, elixir-autogen, elixir-format
 msgid "Optimize a Story"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Report reviewed successfully."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1124
+#: lib/animina_web/live/story_live.ex:1167
 #, elixir-autogen, elixir-format
 msgid "Saving..."
 msgstr ""
@@ -1500,7 +1500,7 @@ msgstr ""
 msgid "To activate your profile you have to have at least an about me story and a profile picture uploaded. A story can contain just a photo, just a text or both combined. You can add, edit and delete stories anytime. With stories you present yourself to others. You have more success with at least three of them in your profile."
 msgstr ""
 
-#: lib/animina_web/live/story_live.ex:1031
+#: lib/animina_web/live/story_live.ex:1074
 #, elixir-autogen, elixir-format
 msgid "Update Photo"
 msgstr ""
@@ -1650,4 +1650,24 @@ msgstr ""
 #: lib/animina_web/components/top_navigation_components.ex:456
 #, elixir-autogen, elixir-format
 msgid "page to activate it again."
+msgstr ""
+
+#: lib/animina_web/live/story_live.ex:1045
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Are you sure you want to delete this photo ?"
+msgstr ""
+
+#: lib/animina_web/live/story_live.ex:1039
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete your about me photo ? This will hibernate your account until you upload another photo"
+msgstr ""
+
+#: lib/animina_web/live/profile_photo_live.ex:310
+#, elixir-autogen, elixir-format
+msgid "Are you sure you want to delete your profile photo ? This will hibernate your account until you upload another photo"
+msgstr ""
+
+#: lib/animina_web/live/story_live.ex:475
+#, elixir-autogen, elixir-format
+msgid "Photo removed successfully !"
 msgstr ""

--- a/test/animina/accounts/photo_test.exs
+++ b/test/animina/accounts/photo_test.exs
@@ -3,6 +3,8 @@ defmodule Animina.Accounts.PhotoTest do
   alias Animina.Accounts.OptimizedPhoto
   alias Animina.Accounts.Photo
   alias Animina.Accounts.User
+  alias Animina.Narratives.Headline
+  alias Animina.Narratives.Story
 
   describe "Tests for Photo Resource" do
     test "A user can create a photo with the required attributes" do
@@ -129,6 +131,107 @@ defmodule Animina.Accounts.PhotoTest do
 
       assert Enum.empty?(photos) == false
     end
+
+    test "Once a user deletes their profile photo , their state changes to hibernated" do
+      {:ok, user} = create_first_user()
+
+      assert user.state == :normal
+
+      # we ensure the story_id is nil , which means it is a profile photo
+      assert {:ok, photo} =
+               Photo.create(%{
+                 filename: "filename",
+                 original_filename: "original_filename",
+                 mime: "mime",
+                 size: 100,
+                 user_id: user.id,
+                 ext: "ext"
+               })
+
+      #  we delete the photo
+
+      assert :ok = Photo.destroy(photo)
+
+      assert {:ok, user} = User.by_id(user.id)
+
+      # we now can see the state of the user changes to hibernate
+
+      assert user.state == :hibernate
+    end
+
+    test "Once a user deletes their about me photo , their state changes to hibernated" do
+      {:ok, user} = create_first_user()
+
+      assert {:ok, about_me_story} = create_about_me_story(user.id, get_about_me_headline().id)
+
+      assert user.state == :normal
+
+      # we create a photo for the about me story
+      assert {:ok, photo} =
+               Photo.create(%{
+                 filename: "filename",
+                 original_filename: "original_filename",
+                 mime: "mime",
+                 size: 100,
+                 story_id: about_me_story.id,
+                 user_id: user.id,
+                 ext: "ext"
+               })
+
+      #  we delete the photo
+
+      assert :ok = Photo.destroy(photo)
+
+      assert {:ok, user} = User.by_id(user.id)
+
+      # we now can see the state of the user changes to hibernate
+
+      assert user.state == :hibernate
+    end
+
+    test "A user can delete any other photo apart from the about me photo and the profile photo and
+          their state does not change" do
+      {:ok, user} = create_first_user()
+
+      assert {:ok, about_me_story} = create_about_me_story(user.id, get_about_me_headline().id)
+
+      assert {:ok, _about_me_photo} =
+               Photo.create(%{
+                 filename: "filename",
+                 original_filename: "original_filename",
+                 mime: "mime",
+                 size: 100,
+                 story_id: about_me_story.id,
+                 user_id: user.id,
+                 ext: "ext"
+               })
+
+      assert {:ok, non_about_me_story} =
+               create_non_about_me_story(user.id, get_non_about_me_headline().id)
+
+      assert {:ok, non_about_me_photo} =
+               Photo.create(%{
+                 filename: "filename",
+                 original_filename: "original_filename",
+                 mime: "mime",
+                 size: 100,
+                 story_id: non_about_me_story.id,
+                 user_id: user.id,
+                 ext: "ext"
+               })
+
+      assert user.state == :normal
+
+      #  we delete the non about me photo
+
+      assert :ok = Photo.destroy(non_about_me_photo)
+
+      assert {:ok, user} = User.by_id(user.id)
+
+      # we now can see the state of the user does not change
+
+      assert user.state == :normal
+    end
   end
 
   defp create_first_user do
@@ -146,5 +249,59 @@ defmodule Animina.Accounts.PhotoTest do
       country: "Germany",
       legal_terms_accepted: true
     })
+  end
+
+  defp create_about_me_story(user_id, headline_id) do
+    Story.create(%{
+      user_id: user_id,
+      headline_id: headline_id,
+      content: "This is a story about me",
+      position: 1
+    })
+  end
+
+  defp get_non_about_me_headline do
+    {:ok, headlines} = Headline.read()
+
+    case headlines do
+      [] ->
+        {:ok, headline} =
+          Headline.create(%{
+            subject: "Non About me",
+            position: 91
+          })
+
+        headline
+
+      _ ->
+        headlines
+        |> Enum.filter(&(&1.subject != "About me"))
+        |> Enum.random()
+    end
+  end
+
+  defp create_non_about_me_story(user_id, headline_id) do
+    Story.create(%{
+      user_id: user_id,
+      headline_id: headline_id,
+      content: "This is a story about me",
+      position: 2
+    })
+  end
+
+  defp get_about_me_headline do
+    case Headline.by_subject("About me") do
+      {:ok, headline} ->
+        headline
+
+      _ ->
+        {:ok, headline} =
+          Headline.create(%{
+            subject: "About me",
+            position: 90
+          })
+
+        headline
+    end
   end
 end


### PR DESCRIPTION
- In this PR I worked on handling of  the profile photo and the about me photo , we allow the user to delete both of these but with a popup telling them the consequneces , if they delete the photos , we make the account hibernate and they can see the banner , after reuploading the photos , we reactivate the account.
- I also changed the code for seeding our data as it was using the profile photo as the about me photo which meant that when we delete the profile photo , we also delete the about me photo which should not be the case , I have now added a seperate photo for the about me story.
- I have added unit tests for the photo resource for this functionality.


**SCENARIO 1: DELETING PROFILE PHOTO**

When a user deletes a profile photo , we hibernate their account , before they do , they see a modal with the text
 "Are you sure you want to delete your about me photo ? This will hibernate your account until you upload another photo".
Once they reupload the profile photo and the about me story also has a photo , we reactivate this account


https://github.com/user-attachments/assets/dd4dab75-d3e7-49da-b519-51bf0afd4709


**SCENARIO 2: DELETING ABOUT ME STORY PHOTO**

When a user deletes the about me story photo , we hibernate their account , before they do , they see a modal with the text
 "Are you sure you want to delete your profile photo ? This will hibernate your account until you upload another photo".
Once they reupload the  photo and the user has a profile photo  , we reactivate this account


https://github.com/user-attachments/assets/ca843803-50bf-420f-abf6-4226bcc9f6cf


**SCENARIO 3: DELETING NORMAL STORY PHOTO**

We now allow the user to delete a normal story photo.


https://github.com/user-attachments/assets/837acf51-5b54-4190-a3c0-e09fb737b1a2






