### PR TITLE
Ensured a user with no photo or about me story image can hibernate , closes #1139 , closes #1134

### DIFF
--- a/lib/animina/accounts/resources/photo.ex
+++ b/lib/animina/accounts/resources/photo.ex
@@ -450,7 +450,7 @@ defmodule Animina.Accounts.Photo do
     end
   end
 
-  defp user_has_an_about_me_story_with_image?(user) do
+  def user_has_an_about_me_story_with_image?(user) do
     case get_stories_for_a_user(user) do
       [] ->
         false

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -382,6 +382,10 @@ defmodule Animina.Accounts.User do
     policy action_type(:read) do
       authorize_if Animina.Checks.ReadProfileCheck
     end
+
+    policy action_type(:update) do
+      authorize_if Animina.Checks.UpdateUserStateCheck
+    end
   end
 
   pub_sub do
@@ -464,6 +468,7 @@ defmodule Animina.Accounts.User do
     validate {Validations.Country, attribute: :country}
 
     validate {Validations.RegistrationCompletedAt, attribute: :registration_completed_at}
+    validate {Animina.Validations.ReactivateUser, attribute: :state}, on: :update
   end
 
   attributes do

--- a/lib/animina/validations/reactivate_user.ex
+++ b/lib/animina/validations/reactivate_user.ex
@@ -1,0 +1,59 @@
+defmodule Animina.Validations.ReactivateUser do
+  use Ash.Resource.Validation
+  alias Animina.Accounts.User
+  alias Animina.Narratives.Story
+
+  @moduledoc """
+  This is a module for ensuring the user
+  """
+
+  @impl true
+  def init(opts) do
+    case is_atom(opts[:attribute]) do
+      true -> {:ok, opts}
+      _ -> {:error, "attribute must be an atom!"}
+    end
+  end
+
+  @impl true
+  def validate(changeset, _opts, _context) do
+    check_if_user_can_reactivate(changeset.action.name, changeset.data.id)
+  end
+
+  defp check_if_user_can_reactivate(:reactivate, user_id) do
+    user = User.by_id!(user_id)
+
+    if user_has_an_about_me_story_with_image?(user) && user.profile_photo != nil do
+      :ok
+    else
+      {:error,
+       field: :reactivate,
+       message:
+         "You cannot reactivate the user, because the user does not have an about me story with an image or a profile photo"}
+    end
+  end
+
+  defp check_if_user_can_reactivate(_, _) do
+    :ok
+  end
+
+  def user_has_an_about_me_story_with_image?(user) do
+    case get_stories_for_a_user(user) do
+      [] ->
+        false
+
+      stories ->
+        stories
+        |> Enum.find(fn story -> story.headline.subject == "About me" end)
+        |> case do
+          nil -> false
+          story -> not is_nil(story.photo)
+        end
+    end
+  end
+
+  defp get_stories_for_a_user(user) do
+    {:ok, stories} = Story.by_user_id(user.id)
+    stories
+  end
+end

--- a/lib/animina_web/components/profile/profile_components.ex
+++ b/lib/animina_web/components/profile/profile_components.ex
@@ -571,7 +571,11 @@ defmodule AniminaWeb.ProfileComponents do
           "change_user_state"
         end
       }
-      data-confirm={"Are you sure you want to change from #{@value} to #{@state}?"}
+      data-confirm={
+        if @state != @value || @state != @similar_value do
+          "Are you sure you want to change from #{@value} to #{@state}?"
+        end
+      }
       phx-value-state={@state}
       phx-value-action={@action}
       id={"user-state-#{@value}"}

--- a/lib/animina_web/components/profile/profile_components.ex
+++ b/lib/animina_web/components/profile/profile_components.ex
@@ -573,7 +573,12 @@ defmodule AniminaWeb.ProfileComponents do
       }
       data-confirm={
         if @state != @value || @state != @similar_value do
-          "Are you sure you want to change from #{@value} to #{@state}?"
+          with_locale(@language, fn ->
+            gettext("Are you sure you want to change from %{value} to %{state}?",
+              value: @value,
+              state: @state
+            )
+          end)
         end
       }
       phx-value-state={@state}

--- a/lib/animina_web/live/profile_visibility.ex
+++ b/lib/animina_web/live/profile_visibility.ex
@@ -165,7 +165,7 @@ defmodule AniminaWeb.ProfileVisibilityLive do
     end
   end
 
-  defp maybe_change_user_state("hibernate", socket, _profile_photo, true) do
+  defp maybe_change_user_state("hibernate", socket, _profile_photo, _) do
     case change_user_state("hibernate", socket.assigns.current_user) do
       {:ok, user} ->
         {:noreply,

--- a/lib/animina_web/live/profile_visibility.ex
+++ b/lib/animina_web/live/profile_visibility.ex
@@ -127,7 +127,7 @@ defmodule AniminaWeb.ProfileVisibilityLive do
      )}
   end
 
-  defp maybe_change_user_state("normalize", socket, profile_photo, false) do
+  defp maybe_change_user_state("normalize", socket, _profile_photo, false) do
     {:noreply,
      socket
      |> put_flash(
@@ -140,7 +140,7 @@ defmodule AniminaWeb.ProfileVisibilityLive do
      )}
   end
 
-  defp maybe_change_user_state("normalize", socket, profile_photo, true) do
+  defp maybe_change_user_state("normalize", socket, _profile_photo, true) do
     case change_user_state("normalize", socket.assigns.current_user) do
       {:ok, user} ->
         {:noreply,
@@ -165,7 +165,7 @@ defmodule AniminaWeb.ProfileVisibilityLive do
     end
   end
 
-  defp maybe_change_user_state("hibernate", socket, profile_photo, true) do
+  defp maybe_change_user_state("hibernate", socket, _profile_photo, true) do
     case change_user_state("hibernate", socket.assigns.current_user) do
       {:ok, user} ->
         {:noreply,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr "Abbrechen"
 msgid "Change Profile Photo"
 msgstr "Profilfoto ändern"
 
-#: lib/animina_web/live/profile_visibility.ex:124
+#: lib/animina_web/live/profile_visibility.ex:207
 #, elixir-autogen, elixir-format
 msgid "Change Profile Visibility"
 msgstr "Profil-Sichtbarkeit ändern"
@@ -503,7 +503,7 @@ msgstr "Hier sind einige Ideen. Kopieren Sie eine und passen Sie sie an (z. B. e
 msgid "Hi"
 msgstr "Hallo"
 
-#: lib/animina_web/components/profile/profile_components.ex:623
+#: lib/animina_web/components/profile/profile_components.ex:627
 #, elixir-autogen, elixir-format
 msgid "Hibernate"
 msgstr "Ruhezustand"
@@ -696,7 +696,7 @@ msgstr "Keine Berichte verfügbar"
 msgid "No bookmarks found"
 msgstr "Keine Lesezeichen gefunden"
 
-#: lib/animina_web/components/profile/profile_components.ex:611
+#: lib/animina_web/components/profile/profile_components.ex:615
 #, elixir-autogen, elixir-format
 msgid "Normal"
 msgstr "Normal"
@@ -818,12 +818,14 @@ msgstr "Profilfoto erfolgreich gelöscht"
 msgid "Profile updated successfully"
 msgstr "Profil erfolgreich aktualisiert"
 
-#: lib/animina_web/live/profile_visibility.ex:85
+#: lib/animina_web/live/profile_visibility.ex:162
+#: lib/animina_web/live/profile_visibility.ex:187
 #, elixir-autogen, elixir-format
 msgid "Profile visibility change failed."
 msgstr "Profil-Sichtbarkeitsänderung fehlgeschlagen."
 
-#: lib/animina_web/live/profile_visibility.ex:82
+#: lib/animina_web/live/profile_visibility.ex:152
+#: lib/animina_web/live/profile_visibility.ex:177
 #, elixir-autogen, elixir-format
 msgid "Profile visibility changed successfully."
 msgstr "Profil-Sichtbarkeit erfolgreich geändert."
@@ -940,7 +942,7 @@ msgstr "Suchbereich"
 msgid "Seconds Remaining"
 msgstr "Verbleibende Sekunden"
 
-#: lib/animina_web/live/profile_visibility.ex:129
+#: lib/animina_web/live/profile_visibility.ex:212
 #, elixir-autogen, elixir-format
 msgid "Select And Change the visibility of your profile"
 msgstr "Wählen und ändern Sie die Sichtbarkeit Ihres Profils"
@@ -1055,12 +1057,12 @@ msgstr "Der Ball bleibt in meinem Posteingang."
 msgid "The following users are on the waitlist"
 msgstr "Die folgenden Nutzer stehen auf der Warteliste"
 
-#: lib/animina_web/components/profile/profile_components.ex:617
+#: lib/animina_web/components/profile/profile_components.ex:621
 #, elixir-autogen, elixir-format
 msgid "The user is actively using the account, engaging with posts and other users."
 msgstr "Der Nutzer verwendet das Konto aktiv und interagiert mit Beiträgen und anderen Nutzern."
 
-#: lib/animina_web/components/profile/profile_components.ex:629
+#: lib/animina_web/components/profile/profile_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "The user is temporarily inactive but retains their account and data for future use."
 msgstr "Der Nutzer ist vorübergehend inaktiv, behält jedoch sein Konto und seine Daten für die zukünftige Nutzung."
@@ -1622,12 +1624,12 @@ msgstr "Falls Sie kein Konto erstellt haben, ignorieren Sie diese Nachricht. Wir
 msgid "This email was sent by the ANIMINA system. Please do not reply to it."
 msgstr "Diese E-Mail wurde vom ANIMINA-System gesendet. Bitte antworten Sie nicht darauf."
 
-#: lib/animina_web/components/profile/profile_components.ex:597
+#: lib/animina_web/components/profile/profile_components.ex:601
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Change To This State"
 msgstr "Zu diesem Status wechseln"
 
-#: lib/animina_web/components/profile/profile_components.ex:650
+#: lib/animina_web/components/profile/profile_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Currently active"
 msgstr "Derzeit aktiv"
@@ -1657,7 +1659,6 @@ msgstr "Seite, um es wieder zu aktivieren."
 msgid "Are you sure you want to delete this photo ?"
 msgstr "Sind Sie sicher, dass Sie Ihr Konto löschen möchten?"
 
-
 #: lib/animina_web/live/story_live.ex:1039
 #, elixir-autogen, elixir-format
 msgid "Are you sure you want to delete your about me photo ? This will hibernate your account until you upload another photo"
@@ -1672,3 +1673,18 @@ msgstr "Möchten Sie Ihr Profilfoto wirklich löschen? Ihr Konto wird pausiert, 
 #, elixir-autogen, elixir-format
 msgid "Photo removed successfully !"
 msgstr "Foto erfolgreich entfernt!"
+
+#: lib/animina_web/live/profile_visibility.ex:136
+#, elixir-autogen, elixir-format
+msgid "You need to have a photo for your about me story to change your profile visibility."
+msgstr "Sie müssen ein Foto für Ihre Über-mich-Geschichte haben, um die Sichtbarkeit Ihres Profils zu ändern."
+
+#: lib/animina_web/live/profile_visibility.ex:113
+#, elixir-autogen, elixir-format
+msgid "You need to have a profile photo and a photo for your about me story\n      to change your profile visibility."
+msgstr "Sie müssen ein Profilfoto und ein Foto für Ihre Über-mich-Geschichte haben,\n      um die Sichtbarkeit Ihres Profils zu ändern."
+
+#: lib/animina_web/live/profile_visibility.ex:125
+#, elixir-autogen, elixir-format
+msgid "You need to have a profile photo to change your profile visibility."
+msgstr "Sie müssen ein Profilfoto haben, um die Sichtbarkeit Ihres Profils zu ändern."

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr "Abbrechen"
 msgid "Change Profile Photo"
 msgstr "Profilfoto ändern"
 
-#: lib/animina_web/live/profile_visibility.ex:207
+#: lib/animina_web/live/profile_visibility.ex:189
 #, elixir-autogen, elixir-format
 msgid "Change Profile Visibility"
 msgstr "Profil-Sichtbarkeit ändern"
@@ -503,7 +503,7 @@ msgstr "Hier sind einige Ideen. Kopieren Sie eine und passen Sie sie an (z. B. e
 msgid "Hi"
 msgstr "Hallo"
 
-#: lib/animina_web/components/profile/profile_components.ex:627
+#: lib/animina_web/components/profile/profile_components.ex:632
 #, elixir-autogen, elixir-format
 msgid "Hibernate"
 msgstr "Ruhezustand"
@@ -696,7 +696,7 @@ msgstr "Keine Berichte verfügbar"
 msgid "No bookmarks found"
 msgstr "Keine Lesezeichen gefunden"
 
-#: lib/animina_web/components/profile/profile_components.ex:615
+#: lib/animina_web/components/profile/profile_components.ex:620
 #, elixir-autogen, elixir-format
 msgid "Normal"
 msgstr "Normal"
@@ -818,14 +818,12 @@ msgstr "Profilfoto erfolgreich gelöscht"
 msgid "Profile updated successfully"
 msgstr "Profil erfolgreich aktualisiert"
 
-#: lib/animina_web/live/profile_visibility.ex:162
-#: lib/animina_web/live/profile_visibility.ex:187
+#: lib/animina_web/live/profile_visibility.ex:169
 #, elixir-autogen, elixir-format
 msgid "Profile visibility change failed."
 msgstr "Profil-Sichtbarkeitsänderung fehlgeschlagen."
 
-#: lib/animina_web/live/profile_visibility.ex:152
-#: lib/animina_web/live/profile_visibility.ex:177
+#: lib/animina_web/live/profile_visibility.ex:159
 #, elixir-autogen, elixir-format
 msgid "Profile visibility changed successfully."
 msgstr "Profil-Sichtbarkeit erfolgreich geändert."
@@ -942,7 +940,7 @@ msgstr "Suchbereich"
 msgid "Seconds Remaining"
 msgstr "Verbleibende Sekunden"
 
-#: lib/animina_web/live/profile_visibility.ex:212
+#: lib/animina_web/live/profile_visibility.ex:194
 #, elixir-autogen, elixir-format
 msgid "Select And Change the visibility of your profile"
 msgstr "Wählen und ändern Sie die Sichtbarkeit Ihres Profils"
@@ -1057,12 +1055,12 @@ msgstr "Der Ball bleibt in meinem Posteingang."
 msgid "The following users are on the waitlist"
 msgstr "Die folgenden Nutzer stehen auf der Warteliste"
 
-#: lib/animina_web/components/profile/profile_components.ex:621
+#: lib/animina_web/components/profile/profile_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "The user is actively using the account, engaging with posts and other users."
 msgstr "Der Nutzer verwendet das Konto aktiv und interagiert mit Beiträgen und anderen Nutzern."
 
-#: lib/animina_web/components/profile/profile_components.ex:633
+#: lib/animina_web/components/profile/profile_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "The user is temporarily inactive but retains their account and data for future use."
 msgstr "Der Nutzer ist vorübergehend inaktiv, behält jedoch sein Konto und seine Daten für die zukünftige Nutzung."
@@ -1624,12 +1622,12 @@ msgstr "Falls Sie kein Konto erstellt haben, ignorieren Sie diese Nachricht. Wir
 msgid "This email was sent by the ANIMINA system. Please do not reply to it."
 msgstr "Diese E-Mail wurde vom ANIMINA-System gesendet. Bitte antworten Sie nicht darauf."
 
-#: lib/animina_web/components/profile/profile_components.ex:601
+#: lib/animina_web/components/profile/profile_components.ex:606
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Change To This State"
 msgstr "Zu diesem Status wechseln"
 
-#: lib/animina_web/components/profile/profile_components.ex:654
+#: lib/animina_web/components/profile/profile_components.ex:659
 #, elixir-autogen, elixir-format
 msgid "Currently active"
 msgstr "Derzeit aktiv"
@@ -1674,17 +1672,7 @@ msgstr "Möchten Sie Ihr Profilfoto wirklich löschen? Ihr Konto wird pausiert, 
 msgid "Photo removed successfully !"
 msgstr "Foto erfolgreich entfernt!"
 
-#: lib/animina_web/live/profile_visibility.ex:136
-#, elixir-autogen, elixir-format
-msgid "You need to have a photo for your about me story to change your profile visibility."
-msgstr "Sie müssen ein Foto für Ihre Über-mich-Geschichte haben, um die Sichtbarkeit Ihres Profils zu ändern."
-
-#: lib/animina_web/live/profile_visibility.ex:113
-#, elixir-autogen, elixir-format
-msgid "You need to have a profile photo and a photo for your about me story\n      to change your profile visibility."
-msgstr "Sie müssen ein Profilfoto und ein Foto für Ihre Über-mich-Geschichte haben,\n      um die Sichtbarkeit Ihres Profils zu ändern."
-
-#: lib/animina_web/live/profile_visibility.ex:125
-#, elixir-autogen, elixir-format
-msgid "You need to have a profile photo to change your profile visibility."
-msgstr "Sie müssen ein Profilfoto haben, um die Sichtbarkeit Ihres Profils zu ändern."
+#: lib/animina_web/components/profile/profile_components.ex:577
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Are you sure you want to change from %{value} to %{state}?"
+msgstr "Sind Sie sicher, dass Sie Ihr Konto löschen möchten?"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Change Profile Photo"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:207
+#: lib/animina_web/live/profile_visibility.ex:189
 #, elixir-autogen, elixir-format
 msgid "Change Profile Visibility"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Hi"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:627
+#: lib/animina_web/components/profile/profile_components.ex:632
 #, elixir-autogen, elixir-format
 msgid "Hibernate"
 msgstr ""
@@ -696,7 +696,7 @@ msgstr ""
 msgid "No bookmarks found"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:615
+#: lib/animina_web/components/profile/profile_components.ex:620
 #, elixir-autogen, elixir-format
 msgid "Normal"
 msgstr ""
@@ -818,14 +818,12 @@ msgstr ""
 msgid "Profile updated successfully"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:162
-#: lib/animina_web/live/profile_visibility.ex:187
+#: lib/animina_web/live/profile_visibility.ex:169
 #, elixir-autogen, elixir-format
 msgid "Profile visibility change failed."
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:152
-#: lib/animina_web/live/profile_visibility.ex:177
+#: lib/animina_web/live/profile_visibility.ex:159
 #, elixir-autogen, elixir-format
 msgid "Profile visibility changed successfully."
 msgstr ""
@@ -942,7 +940,7 @@ msgstr ""
 msgid "Seconds Remaining"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:212
+#: lib/animina_web/live/profile_visibility.ex:194
 #, elixir-autogen, elixir-format
 msgid "Select And Change the visibility of your profile"
 msgstr ""
@@ -1057,12 +1055,12 @@ msgstr ""
 msgid "The following users are on the waitlist"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:621
+#: lib/animina_web/components/profile/profile_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "The user is actively using the account, engaging with posts and other users."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:633
+#: lib/animina_web/components/profile/profile_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "The user is temporarily inactive but retains their account and data for future use."
 msgstr ""
@@ -1624,12 +1622,12 @@ msgstr ""
 msgid "This email was sent by the ANIMINA system. Please do not reply to it."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:601
+#: lib/animina_web/components/profile/profile_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "Change To This State"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:654
+#: lib/animina_web/components/profile/profile_components.ex:659
 #, elixir-autogen, elixir-format
 msgid "Currently active"
 msgstr ""
@@ -1674,17 +1672,7 @@ msgstr ""
 msgid "Photo removed successfully !"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:136
+#: lib/animina_web/components/profile/profile_components.ex:577
 #, elixir-autogen, elixir-format
-msgid "You need to have a photo for your about me story to change your profile visibility."
-msgstr ""
-
-#: lib/animina_web/live/profile_visibility.ex:113
-#, elixir-autogen, elixir-format
-msgid "You need to have a profile photo and a photo for your about me story\n      to change your profile visibility."
-msgstr ""
-
-#: lib/animina_web/live/profile_visibility.ex:125
-#, elixir-autogen, elixir-format
-msgid "You need to have a profile photo to change your profile visibility."
+msgid "Are you sure you want to change from %{value} to %{state}?"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Change Profile Photo"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:124
+#: lib/animina_web/live/profile_visibility.ex:207
 #, elixir-autogen, elixir-format
 msgid "Change Profile Visibility"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Hi"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:623
+#: lib/animina_web/components/profile/profile_components.ex:627
 #, elixir-autogen, elixir-format
 msgid "Hibernate"
 msgstr ""
@@ -696,7 +696,7 @@ msgstr ""
 msgid "No bookmarks found"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:611
+#: lib/animina_web/components/profile/profile_components.ex:615
 #, elixir-autogen, elixir-format
 msgid "Normal"
 msgstr ""
@@ -818,12 +818,14 @@ msgstr ""
 msgid "Profile updated successfully"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:85
+#: lib/animina_web/live/profile_visibility.ex:162
+#: lib/animina_web/live/profile_visibility.ex:187
 #, elixir-autogen, elixir-format
 msgid "Profile visibility change failed."
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:82
+#: lib/animina_web/live/profile_visibility.ex:152
+#: lib/animina_web/live/profile_visibility.ex:177
 #, elixir-autogen, elixir-format
 msgid "Profile visibility changed successfully."
 msgstr ""
@@ -940,7 +942,7 @@ msgstr ""
 msgid "Seconds Remaining"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:129
+#: lib/animina_web/live/profile_visibility.ex:212
 #, elixir-autogen, elixir-format
 msgid "Select And Change the visibility of your profile"
 msgstr ""
@@ -1055,12 +1057,12 @@ msgstr ""
 msgid "The following users are on the waitlist"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:617
+#: lib/animina_web/components/profile/profile_components.ex:621
 #, elixir-autogen, elixir-format
 msgid "The user is actively using the account, engaging with posts and other users."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:629
+#: lib/animina_web/components/profile/profile_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "The user is temporarily inactive but retains their account and data for future use."
 msgstr ""
@@ -1622,12 +1624,12 @@ msgstr ""
 msgid "This email was sent by the ANIMINA system. Please do not reply to it."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:597
+#: lib/animina_web/components/profile/profile_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Change To This State"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:650
+#: lib/animina_web/components/profile/profile_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Currently active"
 msgstr ""
@@ -1670,4 +1672,19 @@ msgstr ""
 #: lib/animina_web/live/story_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Photo removed successfully !"
+msgstr ""
+
+#: lib/animina_web/live/profile_visibility.ex:136
+#, elixir-autogen, elixir-format
+msgid "You need to have a photo for your about me story to change your profile visibility."
+msgstr ""
+
+#: lib/animina_web/live/profile_visibility.ex:113
+#, elixir-autogen, elixir-format
+msgid "You need to have a profile photo and a photo for your about me story\n      to change your profile visibility."
+msgstr ""
+
+#: lib/animina_web/live/profile_visibility.ex:125
+#, elixir-autogen, elixir-format
+msgid "You need to have a profile photo to change your profile visibility."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Change Profile Photo"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:124
+#: lib/animina_web/live/profile_visibility.ex:207
 #, elixir-autogen, elixir-format
 msgid "Change Profile Visibility"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Hi"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:623
+#: lib/animina_web/components/profile/profile_components.ex:627
 #, elixir-autogen, elixir-format
 msgid "Hibernate"
 msgstr ""
@@ -696,7 +696,7 @@ msgstr ""
 msgid "No bookmarks found"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:611
+#: lib/animina_web/components/profile/profile_components.ex:615
 #, elixir-autogen, elixir-format
 msgid "Normal"
 msgstr ""
@@ -818,12 +818,14 @@ msgstr ""
 msgid "Profile updated successfully"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:85
+#: lib/animina_web/live/profile_visibility.ex:162
+#: lib/animina_web/live/profile_visibility.ex:187
 #, elixir-autogen, elixir-format
 msgid "Profile visibility change failed."
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:82
+#: lib/animina_web/live/profile_visibility.ex:152
+#: lib/animina_web/live/profile_visibility.ex:177
 #, elixir-autogen, elixir-format
 msgid "Profile visibility changed successfully."
 msgstr ""
@@ -940,7 +942,7 @@ msgstr ""
 msgid "Seconds Remaining"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:129
+#: lib/animina_web/live/profile_visibility.ex:212
 #, elixir-autogen, elixir-format
 msgid "Select And Change the visibility of your profile"
 msgstr ""
@@ -1055,12 +1057,12 @@ msgstr ""
 msgid "The following users are on the waitlist"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:617
+#: lib/animina_web/components/profile/profile_components.ex:621
 #, elixir-autogen, elixir-format
 msgid "The user is actively using the account, engaging with posts and other users."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:629
+#: lib/animina_web/components/profile/profile_components.ex:633
 #, elixir-autogen, elixir-format
 msgid "The user is temporarily inactive but retains their account and data for future use."
 msgstr ""
@@ -1622,12 +1624,12 @@ msgstr ""
 msgid "This email was sent by the ANIMINA system. Please do not reply to it."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:597
+#: lib/animina_web/components/profile/profile_components.ex:601
 #, elixir-autogen, elixir-format
 msgid "Change To This State"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:650
+#: lib/animina_web/components/profile/profile_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Currently active"
 msgstr ""
@@ -1670,4 +1672,19 @@ msgstr ""
 #: lib/animina_web/live/story_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Photo removed successfully !"
+msgstr ""
+
+#: lib/animina_web/live/profile_visibility.ex:136
+#, elixir-autogen, elixir-format
+msgid "You need to have a photo for your about me story to change your profile visibility."
+msgstr ""
+
+#: lib/animina_web/live/profile_visibility.ex:113
+#, elixir-autogen, elixir-format
+msgid "You need to have a profile photo and a photo for your about me story\n      to change your profile visibility."
+msgstr ""
+
+#: lib/animina_web/live/profile_visibility.ex:125
+#, elixir-autogen, elixir-format
+msgid "You need to have a profile photo to change your profile visibility."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -154,7 +154,7 @@ msgstr ""
 msgid "Change Profile Photo"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:207
+#: lib/animina_web/live/profile_visibility.ex:189
 #, elixir-autogen, elixir-format
 msgid "Change Profile Visibility"
 msgstr ""
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Hi"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:627
+#: lib/animina_web/components/profile/profile_components.ex:632
 #, elixir-autogen, elixir-format
 msgid "Hibernate"
 msgstr ""
@@ -696,7 +696,7 @@ msgstr ""
 msgid "No bookmarks found"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:615
+#: lib/animina_web/components/profile/profile_components.ex:620
 #, elixir-autogen, elixir-format
 msgid "Normal"
 msgstr ""
@@ -818,14 +818,12 @@ msgstr ""
 msgid "Profile updated successfully"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:162
-#: lib/animina_web/live/profile_visibility.ex:187
+#: lib/animina_web/live/profile_visibility.ex:169
 #, elixir-autogen, elixir-format
 msgid "Profile visibility change failed."
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:152
-#: lib/animina_web/live/profile_visibility.ex:177
+#: lib/animina_web/live/profile_visibility.ex:159
 #, elixir-autogen, elixir-format
 msgid "Profile visibility changed successfully."
 msgstr ""
@@ -942,7 +940,7 @@ msgstr ""
 msgid "Seconds Remaining"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:212
+#: lib/animina_web/live/profile_visibility.ex:194
 #, elixir-autogen, elixir-format
 msgid "Select And Change the visibility of your profile"
 msgstr ""
@@ -1057,12 +1055,12 @@ msgstr ""
 msgid "The following users are on the waitlist"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:621
+#: lib/animina_web/components/profile/profile_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "The user is actively using the account, engaging with posts and other users."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:633
+#: lib/animina_web/components/profile/profile_components.ex:638
 #, elixir-autogen, elixir-format
 msgid "The user is temporarily inactive but retains their account and data for future use."
 msgstr ""
@@ -1624,12 +1622,12 @@ msgstr ""
 msgid "This email was sent by the ANIMINA system. Please do not reply to it."
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:601
+#: lib/animina_web/components/profile/profile_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "Change To This State"
 msgstr ""
 
-#: lib/animina_web/components/profile/profile_components.ex:654
+#: lib/animina_web/components/profile/profile_components.ex:659
 #, elixir-autogen, elixir-format
 msgid "Currently active"
 msgstr ""
@@ -1674,17 +1672,7 @@ msgstr ""
 msgid "Photo removed successfully !"
 msgstr ""
 
-#: lib/animina_web/live/profile_visibility.ex:136
-#, elixir-autogen, elixir-format
-msgid "You need to have a photo for your about me story to change your profile visibility."
-msgstr ""
-
-#: lib/animina_web/live/profile_visibility.ex:113
-#, elixir-autogen, elixir-format
-msgid "You need to have a profile photo and a photo for your about me story\n      to change your profile visibility."
-msgstr ""
-
-#: lib/animina_web/live/profile_visibility.ex:125
-#, elixir-autogen, elixir-format
-msgid "You need to have a profile photo to change your profile visibility."
+#: lib/animina_web/components/profile/profile_components.ex:577
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Are you sure you want to change from %{value} to %{state}?"
 msgstr ""

--- a/test/animina_web/live/profile_visibility_test.exs
+++ b/test/animina_web/live/profile_visibility_test.exs
@@ -219,11 +219,26 @@ defmodule AniminaWeb.ProfileVisibilityTest do
   end
 
   defp create_about_me_story(user_id, headline_id) do
-    Story.create(%{
+    {:ok, story} =
+      Story.create(%{
+        user_id: user_id,
+        headline_id: headline_id,
+        content: "This is a story about me",
+        position: 1
+      })
+
+    file_path = Temp.path!(basedir: "priv/static/uploads", suffix: ".jpg")
+
+    file_path_without_uploads = String.replace(file_path, "uploads/", "")
+
+    Photo.create(%{
       user_id: user_id,
-      headline_id: headline_id,
-      content: "This is a story about me",
-      position: 1
+      story_id: story.id,
+      filename: file_path_without_uploads,
+      original_filename: file_path_without_uploads,
+      size: 100,
+      ext: "jpg",
+      mime: "image/jpeg"
     })
   end
 


### PR DESCRIPTION
- I ensured if a user has been hibernated due to lack of profile photo  they see these flash message

https://github.com/user-attachments/assets/6c71506f-6b62-4d78-a897-713166f38e96


"You need to have a profile photo and a photo for your about me story to change your profile visibility." - If a user user has no profile photo and no about me story image

"You need to have a profile photo to change your profile visibility." -  If a user has no profile photo 

"You need to have a photo for your about me story to change your profile visibility." - If a user has no about me story image



