### PR TITLE
Remove unhelpful dropdowns on the email verification page  , closes  #1124

### DIFF
--- a/lib/animina_web/components/top_navigation_components.ex
+++ b/lib/animina_web/components/top_navigation_components.ex
@@ -264,9 +264,15 @@ defmodule AniminaWeb.TopNavigationCompontents do
               <% end) %>
             </.link>
           <% else %>
-            <.link class="px-2 w-[150px] text-center" navigate="/auth/user/sign-out">
+            <.link class="px-2 w-[180px]  text-start" navigate="/auth/user/sign-out">
               <%= with_locale(@language, fn -> %>
                 <%= gettext("Sign Out") %>
+              <% end) %>
+            </.link>
+
+            <.link class="px-2 w-[180px]  text-start" navigate="/my/profile/delete_account">
+              <%= with_locale(@language, fn -> %>
+                <%= gettext("Delete Account") %>
               <% end) %>
             </.link>
           <% end %>

--- a/lib/animina_web/live/auth_live/user_auth.ex
+++ b/lib/animina_web/live/auth_live/user_auth.ex
@@ -207,7 +207,7 @@ defmodule AniminaWeb.LiveUserAuth do
   end
 
   def on_mount(:live_user_required_for_validation, _params, session, socket) do
-    if socket.assigns[:current_user] && socket.assigns[:current_user].confirmed_at == nil do
+    if socket.assigns[:current_user]  do
       current_user = Registration.get_current_user(session)
 
       {:cont,

--- a/lib/animina_web/live/auth_live/user_auth.ex
+++ b/lib/animina_web/live/auth_live/user_auth.ex
@@ -69,21 +69,21 @@ defmodule AniminaWeb.LiveUserAuth do
   end
 
   def on_mount(:live_user_required, _params, session, socket) do
-    _path =
+    path =
       case Map.get(socket.private.connect_info, :request_path, nil) do
         nil ->
-          "sign-in"
+          "/"
 
         path ->
           case Map.get(socket.private.connect_info, :query_string, nil) do
             nil ->
-              "sign-in?redirect_to=" <> path
+              "/sign-in?redirect_to=" <> path
 
             "" ->
-              "sign-in?redirect_to=" <> path
+              "/sign-in?redirect_to=" <> path
 
             query_string ->
-              "sign-in?redirect_to=" <> path <> "?" <> query_string
+              "/sign-in?redirect_to=" <> path <> "?" <> query_string
           end
       end
 
@@ -118,7 +118,7 @@ defmodule AniminaWeb.LiveUserAuth do
     else
       {:halt,
        socket
-       |> Phoenix.LiveView.redirect(to: "/my/email-validation")
+       |> Phoenix.LiveView.redirect(to: path)
        |> Phoenix.LiveView.put_flash(
          :error,
          "You need to be authenticated  confirmed , and have an active account to access this page . If you are already signed up , check your email for the confirmation link"
@@ -148,8 +148,14 @@ defmodule AniminaWeb.LiveUserAuth do
 
   def on_mount(:live_no_user, _params, _session, socket) do
     if socket.assigns[:current_user] do
-      {:halt,
-       Phoenix.LiveView.redirect(socket, to: ~p"/#{socket.assigns[:current_user].username}")}
+      path =
+        if socket.assigns[:current_user].confirmed_at do
+          "/#{socket.assigns[:current_user].username}"
+        else
+          "/my/email-validation"
+        end
+
+      {:halt, Phoenix.LiveView.redirect(socket, to: path)}
     else
       {:cont,
        socket

--- a/lib/animina_web/live/auth_live/user_auth.ex
+++ b/lib/animina_web/live/auth_live/user_auth.ex
@@ -69,7 +69,7 @@ defmodule AniminaWeb.LiveUserAuth do
   end
 
   def on_mount(:live_user_required, _params, session, socket) do
-    path =
+    _path =
       case Map.get(socket.private.connect_info, :request_path, nil) do
         nil ->
           "sign-in"

--- a/lib/animina_web/live/auth_live/user_auth.ex
+++ b/lib/animina_web/live/auth_live/user_auth.ex
@@ -118,7 +118,7 @@ defmodule AniminaWeb.LiveUserAuth do
     else
       {:halt,
        socket
-       |> Phoenix.LiveView.redirect(to: "/#{path}")
+       |> Phoenix.LiveView.redirect(to: "/my/email-validation")
        |> Phoenix.LiveView.put_flash(
          :error,
          "You need to be authenticated  confirmed , and have an active account to access this page . If you are already signed up , check your email for the confirmation link"

--- a/lib/animina_web/live/auth_live/user_auth.ex
+++ b/lib/animina_web/live/auth_live/user_auth.ex
@@ -207,7 +207,7 @@ defmodule AniminaWeb.LiveUserAuth do
   end
 
   def on_mount(:live_user_required_for_validation, _params, session, socket) do
-    if socket.assigns[:current_user]  do
+    if socket.assigns[:current_user] do
       current_user = Registration.get_current_user(session)
 
       {:cont,

--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -549,9 +549,7 @@ defmodule AniminaWeb.RootLive do
                   unless(get_field_errors(f[:legal_terms_accepted], :legal_terms_accepted) == [],
                     do: "ring-red-600 focus:ring-red-600",
                     else: "ring-gray-300 focus:ring-indigo-600"
-                  ),
-              value: f[:legal_terms_accepted].value,
-              "phx-debounce": "200"
+                  )
             ) %>
           </div>
           <div class="text-sm leading-6">

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -67,7 +67,6 @@ defmodule AniminaWeb.Router do
       live "/my/flags/red", FlagsLive, :red
       live "/my/about-me", StoryLive, :about_me
       live "/my/profile/visibility", ProfileVisibilityLive, :index
-
     end
 
     ash_authentication_live_session :authentication_required_and_about_me_story,

--- a/lib/animina_web/router.ex
+++ b/lib/animina_web/router.ex
@@ -40,6 +40,7 @@ defmodule AniminaWeb.Router do
     ash_authentication_live_session :authentication_required_for_email_validation,
       on_mount: {AniminaWeb.LiveUserAuth, :live_user_required_for_validation} do
       live "/my/email-validation", EmailValidationLive, :index
+      live "/my/profile/delete_account", DeleteAccountLive, :index
     end
 
     ash_authentication_live_session :authentication_required_for_too_successful,
@@ -66,7 +67,7 @@ defmodule AniminaWeb.Router do
       live "/my/flags/red", FlagsLive, :red
       live "/my/about-me", StoryLive, :about_me
       live "/my/profile/visibility", ProfileVisibilityLive, :index
-      live "/my/profile/delete_account", DeleteAccountLive, :index
+
     end
 
     ash_authentication_live_session :authentication_required_and_about_me_story,

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -131,8 +131,8 @@ msgstr "Sind Sie sicher, dass Sie Ihr Konto löschen möchten?"
 msgid "Back to Sign In"
 msgstr "Zurück zur Anmeldung"
 
-#: lib/animina_web/components/top_navigation_components.ex:1041
-#: lib/animina_web/components/top_navigation_components.ex:1057
+#: lib/animina_web/components/top_navigation_components.ex:1047
+#: lib/animina_web/components/top_navigation_components.ex:1063
 #: lib/animina_web/live/bookmarks_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
@@ -160,7 +160,7 @@ msgid "Change Profile Visibility"
 msgstr "Profil-Sichtbarkeit ändern"
 
 #: lib/animina_web/components/top_navigation_components.ex:252
-#: lib/animina_web/components/top_navigation_components.ex:452
+#: lib/animina_web/components/top_navigation_components.ex:458
 #, elixir-autogen, elixir-format
 msgid "Change Visibility"
 msgstr "Sichtbarkeit ändern"
@@ -170,7 +170,7 @@ msgstr "Sichtbarkeit ändern"
 msgid "Characters: "
 msgstr "Zeichen: "
 
-#: lib/animina_web/components/top_navigation_components.ex:904
+#: lib/animina_web/components/top_navigation_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "Chat"
 msgstr "Chat"
@@ -224,8 +224,8 @@ msgstr "Kopieren"
 msgid "Copy "
 msgstr "Kopieren"
 
-#: lib/animina_web/components/top_navigation_components.ex:325
-#: lib/animina_web/components/top_navigation_components.ex:375
+#: lib/animina_web/components/top_navigation_components.ex:331
+#: lib/animina_web/components/top_navigation_components.ex:381
 #, elixir-autogen, elixir-format
 msgid "Could Interest You"
 msgstr "Könnte Sie interessieren"
@@ -307,6 +307,7 @@ msgstr "Dating-Coach"
 
 #: lib/animina_web/components/profile/profile_components.ex:538
 #: lib/animina_web/components/profile/profile_components.ex:555
+#: lib/animina_web/components/top_navigation_components.ex:275
 #: lib/animina_web/live/delete_account_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
@@ -508,8 +509,8 @@ msgstr "Hallo"
 msgid "Hibernate"
 msgstr "Ruhezustand"
 
-#: lib/animina_web/components/top_navigation_components.ex:834
-#: lib/animina_web/components/top_navigation_components.ex:864
+#: lib/animina_web/components/top_navigation_components.ex:840
+#: lib/animina_web/components/top_navigation_components.ex:870
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Startseite"
@@ -579,7 +580,7 @@ msgstr "Gefällt mir"
 
 #: lib/animina_web/components/top_navigation_components.ex:104
 #: lib/animina_web/components/top_navigation_components.ex:115
-#: lib/animina_web/components/top_navigation_components.ex:283
+#: lib/animina_web/components/top_navigation_components.ex:289
 #: lib/animina_web/live/root_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Login"
@@ -770,8 +771,8 @@ msgstr "Foto"
 msgid "Please wait a second. We are working on it."
 msgstr "Bitte warten Sie einen Moment. Wir arbeiten daran."
 
-#: lib/animina_web/components/top_navigation_components.ex:644
-#: lib/animina_web/components/top_navigation_components.ex:648
+#: lib/animina_web/components/top_navigation_components.ex:650
+#: lib/animina_web/components/top_navigation_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Points"
 msgstr "Punkte"
@@ -801,8 +802,8 @@ msgstr "Fortfahren"
 msgid "Proceed without selecting a flag"
 msgstr "Fortfahren, ohne ein Flag auszuwählen"
 
-#: lib/animina_web/components/top_navigation_components.ex:1107
-#: lib/animina_web/components/top_navigation_components.ex:1130
+#: lib/animina_web/components/top_navigation_components.ex:1113
+#: lib/animina_web/components/top_navigation_components.ex:1136
 #: lib/animina_web/components/waitlist_components.ex:32
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Profile"
@@ -845,7 +846,7 @@ msgstr "Beitrag lesen"
 msgid "Received"
 msgstr "Erhalten"
 
-#: lib/animina_web/components/top_navigation_components.ex:278
+#: lib/animina_web/components/top_navigation_components.ex:284
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr "Registrieren"
@@ -868,7 +869,7 @@ msgstr "Abgelehnt"
 msgid "Report Account"
 msgstr "Konto melden"
 
-#: lib/animina_web/components/top_navigation_components.ex:671
+#: lib/animina_web/components/top_navigation_components.ex:677
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr "Berichte"
@@ -1210,7 +1211,7 @@ msgstr "Besucht"
 msgid "Visited Profiles"
 msgstr "Besuchte Profile"
 
-#: lib/animina_web/components/top_navigation_components.ex:696
+#: lib/animina_web/components/top_navigation_components.ex:702
 #: lib/animina_web/live/waitlist_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Waitlist"
@@ -1525,8 +1526,8 @@ msgstr " Versuche übrig!"
 msgid "Account Confirmed Successfully"
 msgstr "Konto erfolgreich bestätigt"
 
-#: lib/animina_web/components/top_navigation_components.ex:976
-#: lib/animina_web/components/top_navigation_components.ex:998
+#: lib/animina_web/components/top_navigation_components.ex:982
+#: lib/animina_web/components/top_navigation_components.ex:1004
 #: lib/animina_web/live/my_chats_live.ex:15
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Chats"
@@ -1637,17 +1638,17 @@ msgstr "Derzeit aktiv"
 msgid "Please use this PIN to verify your new ANIMINA account."
 msgstr "Bitte verwenden Sie diesen PIN, um Ihr neues ANIMINA-Konto zu verifizieren."
 
-#: lib/animina_web/components/top_navigation_components.ex:442
+#: lib/animina_web/components/top_navigation_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "This account is hibernated. Other users can't see it or send messages to you."
 msgstr "Dieses Konto ist im Winterschlaf. Andere Benutzer können es nicht sehen oder Ihnen Nachrichten senden."
 
-#: lib/animina_web/components/top_navigation_components.ex:447
+#: lib/animina_web/components/top_navigation_components.ex:453
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Visit the"
 msgstr "Besucht"
 
-#: lib/animina_web/components/top_navigation_components.ex:456
+#: lib/animina_web/components/top_navigation_components.ex:462
 #, elixir-autogen, elixir-format
 msgid "page to activate it again."
 msgstr "Seite, um es wieder zu aktivieren."
@@ -1656,7 +1657,6 @@ msgstr "Seite, um es wieder zu aktivieren."
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure you want to delete this photo ?"
 msgstr "Sind Sie sicher, dass Sie Ihr Konto löschen möchten?"
-
 
 #: lib/animina_web/live/story_live.ex:1039
 #, elixir-autogen, elixir-format

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -131,8 +131,8 @@ msgstr ""
 msgid "Back to Sign In"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:1041
-#: lib/animina_web/components/top_navigation_components.ex:1057
+#: lib/animina_web/components/top_navigation_components.ex:1047
+#: lib/animina_web/components/top_navigation_components.ex:1063
 #: lib/animina_web/live/bookmarks_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
@@ -160,7 +160,7 @@ msgid "Change Profile Visibility"
 msgstr ""
 
 #: lib/animina_web/components/top_navigation_components.ex:252
-#: lib/animina_web/components/top_navigation_components.ex:452
+#: lib/animina_web/components/top_navigation_components.ex:458
 #, elixir-autogen, elixir-format
 msgid "Change Visibility"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "Characters: "
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:904
+#: lib/animina_web/components/top_navigation_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "Chat"
 msgstr ""
@@ -224,8 +224,8 @@ msgstr ""
 msgid "Copy "
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:325
-#: lib/animina_web/components/top_navigation_components.ex:375
+#: lib/animina_web/components/top_navigation_components.ex:331
+#: lib/animina_web/components/top_navigation_components.ex:381
 #, elixir-autogen, elixir-format
 msgid "Could Interest You"
 msgstr ""
@@ -307,6 +307,7 @@ msgstr ""
 
 #: lib/animina_web/components/profile/profile_components.ex:538
 #: lib/animina_web/components/profile/profile_components.ex:555
+#: lib/animina_web/components/top_navigation_components.ex:275
 #: lib/animina_web/live/delete_account_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
@@ -508,8 +509,8 @@ msgstr ""
 msgid "Hibernate"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:834
-#: lib/animina_web/components/top_navigation_components.ex:864
+#: lib/animina_web/components/top_navigation_components.ex:840
+#: lib/animina_web/components/top_navigation_components.ex:870
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -579,7 +580,7 @@ msgstr ""
 
 #: lib/animina_web/components/top_navigation_components.ex:104
 #: lib/animina_web/components/top_navigation_components.ex:115
-#: lib/animina_web/components/top_navigation_components.ex:283
+#: lib/animina_web/components/top_navigation_components.ex:289
 #: lib/animina_web/live/root_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Login"
@@ -770,8 +771,8 @@ msgstr ""
 msgid "Please wait a second. We are working on it."
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:644
-#: lib/animina_web/components/top_navigation_components.ex:648
+#: lib/animina_web/components/top_navigation_components.ex:650
+#: lib/animina_web/components/top_navigation_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Points"
 msgstr ""
@@ -801,8 +802,8 @@ msgstr ""
 msgid "Proceed without selecting a flag"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:1107
-#: lib/animina_web/components/top_navigation_components.ex:1130
+#: lib/animina_web/components/top_navigation_components.ex:1113
+#: lib/animina_web/components/top_navigation_components.ex:1136
 #: lib/animina_web/components/waitlist_components.ex:32
 #, elixir-autogen, elixir-format
 msgid "Profile"
@@ -845,7 +846,7 @@ msgstr ""
 msgid "Received"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:278
+#: lib/animina_web/components/top_navigation_components.ex:284
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Report Account"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:671
+#: lib/animina_web/components/top_navigation_components.ex:677
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr ""
@@ -1210,7 +1211,7 @@ msgstr ""
 msgid "Visited Profiles"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:696
+#: lib/animina_web/components/top_navigation_components.ex:702
 #: lib/animina_web/live/waitlist_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Waitlist"
@@ -1525,8 +1526,8 @@ msgstr ""
 msgid "Account Confirmed Successfully"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:976
-#: lib/animina_web/components/top_navigation_components.ex:998
+#: lib/animina_web/components/top_navigation_components.ex:982
+#: lib/animina_web/components/top_navigation_components.ex:1004
 #: lib/animina_web/live/my_chats_live.ex:15
 #, elixir-autogen, elixir-format
 msgid "Chats"
@@ -1637,17 +1638,17 @@ msgstr ""
 msgid "Please use this PIN to verify your new ANIMINA account."
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:442
+#: lib/animina_web/components/top_navigation_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "This account is hibernated. Other users can't see it or send messages to you."
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:447
+#: lib/animina_web/components/top_navigation_components.ex:453
 #, elixir-autogen, elixir-format
 msgid "Visit the"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:456
+#: lib/animina_web/components/top_navigation_components.ex:462
 #, elixir-autogen, elixir-format
 msgid "page to activate it again."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -131,8 +131,8 @@ msgstr ""
 msgid "Back to Sign In"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:1041
-#: lib/animina_web/components/top_navigation_components.ex:1057
+#: lib/animina_web/components/top_navigation_components.ex:1047
+#: lib/animina_web/components/top_navigation_components.ex:1063
 #: lib/animina_web/live/bookmarks_live.ex:37
 #, elixir-autogen, elixir-format
 msgid "Bookmarks"
@@ -160,7 +160,7 @@ msgid "Change Profile Visibility"
 msgstr ""
 
 #: lib/animina_web/components/top_navigation_components.ex:252
-#: lib/animina_web/components/top_navigation_components.ex:452
+#: lib/animina_web/components/top_navigation_components.ex:458
 #, elixir-autogen, elixir-format
 msgid "Change Visibility"
 msgstr ""
@@ -170,7 +170,7 @@ msgstr ""
 msgid "Characters: "
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:904
+#: lib/animina_web/components/top_navigation_components.ex:910
 #, elixir-autogen, elixir-format
 msgid "Chat"
 msgstr ""
@@ -224,8 +224,8 @@ msgstr ""
 msgid "Copy "
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:325
-#: lib/animina_web/components/top_navigation_components.ex:375
+#: lib/animina_web/components/top_navigation_components.ex:331
+#: lib/animina_web/components/top_navigation_components.ex:381
 #, elixir-autogen, elixir-format
 msgid "Could Interest You"
 msgstr ""
@@ -307,6 +307,7 @@ msgstr ""
 
 #: lib/animina_web/components/profile/profile_components.ex:538
 #: lib/animina_web/components/profile/profile_components.ex:555
+#: lib/animina_web/components/top_navigation_components.ex:275
 #: lib/animina_web/live/delete_account_live.ex:155
 #, elixir-autogen, elixir-format
 msgid "Delete Account"
@@ -508,8 +509,8 @@ msgstr ""
 msgid "Hibernate"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:834
-#: lib/animina_web/components/top_navigation_components.ex:864
+#: lib/animina_web/components/top_navigation_components.ex:840
+#: lib/animina_web/components/top_navigation_components.ex:870
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -579,7 +580,7 @@ msgstr ""
 
 #: lib/animina_web/components/top_navigation_components.ex:104
 #: lib/animina_web/components/top_navigation_components.ex:115
-#: lib/animina_web/components/top_navigation_components.ex:283
+#: lib/animina_web/components/top_navigation_components.ex:289
 #: lib/animina_web/live/root_live.ex:127
 #, elixir-autogen, elixir-format
 msgid "Login"
@@ -770,8 +771,8 @@ msgstr ""
 msgid "Please wait a second. We are working on it."
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:644
-#: lib/animina_web/components/top_navigation_components.ex:648
+#: lib/animina_web/components/top_navigation_components.ex:650
+#: lib/animina_web/components/top_navigation_components.ex:654
 #, elixir-autogen, elixir-format
 msgid "Points"
 msgstr ""
@@ -801,8 +802,8 @@ msgstr ""
 msgid "Proceed without selecting a flag"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:1107
-#: lib/animina_web/components/top_navigation_components.ex:1130
+#: lib/animina_web/components/top_navigation_components.ex:1113
+#: lib/animina_web/components/top_navigation_components.ex:1136
 #: lib/animina_web/components/waitlist_components.ex:32
 #, elixir-autogen, elixir-format
 msgid "Profile"
@@ -845,7 +846,7 @@ msgstr ""
 msgid "Received"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:278
+#: lib/animina_web/components/top_navigation_components.ex:284
 #, elixir-autogen, elixir-format
 msgid "Register"
 msgstr ""
@@ -868,7 +869,7 @@ msgstr ""
 msgid "Report Account"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:671
+#: lib/animina_web/components/top_navigation_components.ex:677
 #, elixir-autogen, elixir-format
 msgid "Reports"
 msgstr ""
@@ -1210,7 +1211,7 @@ msgstr ""
 msgid "Visited Profiles"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:696
+#: lib/animina_web/components/top_navigation_components.ex:702
 #: lib/animina_web/live/waitlist_live.ex:31
 #, elixir-autogen, elixir-format
 msgid "Waitlist"
@@ -1525,8 +1526,8 @@ msgstr ""
 msgid "Account Confirmed Successfully"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:976
-#: lib/animina_web/components/top_navigation_components.ex:998
+#: lib/animina_web/components/top_navigation_components.ex:982
+#: lib/animina_web/components/top_navigation_components.ex:1004
 #: lib/animina_web/live/my_chats_live.ex:15
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Chats"
@@ -1637,17 +1638,17 @@ msgstr ""
 msgid "Please use this PIN to verify your new ANIMINA account."
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:442
+#: lib/animina_web/components/top_navigation_components.ex:448
 #, elixir-autogen, elixir-format
 msgid "This account is hibernated. Other users can't see it or send messages to you."
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:447
+#: lib/animina_web/components/top_navigation_components.ex:453
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Visit the"
 msgstr ""
 
-#: lib/animina_web/components/top_navigation_components.ex:456
+#: lib/animina_web/components/top_navigation_components.ex:462
 #, elixir-autogen, elixir-format
 msgid "page to activate it again."
 msgstr ""


### PR DESCRIPTION
We now have the email verificatio page having only 2 options , Log out or delete account.
![Screenshot 2024-11-20 at 08 06 57](https://github.com/user-attachments/assets/f7b3d026-8b4e-4204-936f-e42ad4b282e1)
