### PR TITLE
Ensured you can click on the checkbox once in registration , closes #1119

### DIFF
--- a/lib/animina_web/live/root_live.ex
+++ b/lib/animina_web/live/root_live.ex
@@ -549,9 +549,7 @@ defmodule AniminaWeb.RootLive do
                   unless(get_field_errors(f[:legal_terms_accepted], :legal_terms_accepted) == [],
                     do: "ring-red-600 focus:ring-red-600",
                     else: "ring-gray-300 focus:ring-indigo-600"
-                  ),
-              value: f[:legal_terms_accepted].value,
-              "phx-debounce": "200"
+                  )
             ) %>
           </div>
           <div class="text-sm leading-6">


### PR DESCRIPTION
I removed phx-debounce and ensured you only need to click on the checkbox once during registration

https://github.com/user-attachments/assets/a640a2f5-7dfc-44dc-933b-0c669ebee374

