### PR TITLE
Added dynamic number of days to use when checking when users registered

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -66,6 +66,9 @@ config :animina, AniminaWeb.Endpoint,
 # Enable dev routes for dashboard and mailbox
 config :animina, dev_routes: true
 
+# configures the number of days behind we check when showing users on the sidebar for potential partners
+config :animina, :number_of_days_to_filter_registered_users, 60
+
 # Configures the llama version
 config :animina, :llm_version, "llama3.1:8b"
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -33,5 +33,9 @@ config :logger, level: :info
 # Configures the llama version
 config :animina, :llm_version, "llama3.1:8b"
 
+# configures the number of days behind we check when showing users on the sidebar for potential partners
+
+config :animina, :number_of_days_to_filter_registered_users, 600
+
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,6 +33,10 @@ config :logger, level: :warning
 
 config :animina, :max_users_per_hour, 5
 
+# configures the number of days behind we check when showing users on the sidebar for potential partners
+
+config :animina, :number_of_days_to_filter_registered_users, 60
+
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 

--- a/lib/animina/accounts/resources/fast_user.ex
+++ b/lib/animina/accounts/resources/fast_user.ex
@@ -29,19 +29,24 @@ defmodule Animina.Accounts.FastUser do
     domain Animina.Accounts
     define :by_id_email_or_username
     define :list
-    define :public_users_who_created_an_account_in_the_last_60_days
+    define :public_users_who_created_an_account_in_the_last_number_of_days
   end
 
   actions do
     defaults []
 
-    action :public_users_who_created_an_account_in_the_last_60_days, :map do
+    action :public_users_who_created_an_account_in_the_last_number_of_days, :map do
       argument :limit, :integer, default: 10
       argument :page, :integer, default: 1, constraints: [min: 1]
       argument :gender, :string, allow_nil?: false
 
       run fn input, _ ->
-        date = DateTime.add(DateTime.utc_now(), -60, :day)
+        date =
+          DateTime.add(
+            DateTime.utc_now(),
+            -Application.get_env(:animina, :number_of_days_to_filter_registered_users),
+            :day
+          )
 
         # we dont need to filter by id, username or email. So we pass true as filter
         # but pass extra filters in the options keyword list

--- a/lib/animina/accounts/resources/user.ex
+++ b/lib/animina/accounts/resources/user.ex
@@ -120,8 +120,8 @@ defmodule Animina.Accounts.User do
     define :by_username_as_an_actor, args: [:username]
     define :custom_sign_in, get?: true
     define :request_password_reset_with_password
-    define :female_public_users_who_created_an_account_in_the_last_60_days
-    define :male_public_users_who_created_an_account_in_the_last_60_days
+    define :female_public_users_who_created_an_account_in_the_last_number_of_days
+    define :male_public_users_who_created_an_account_in_the_last_number_of_days
     define :users_in_waitlist
     define :investigate
     define :give_user_in_waitlist_access
@@ -243,9 +243,14 @@ defmodule Animina.Accounts.User do
       filter expr(username == ^arg(:username))
     end
 
-    read :female_public_users_who_created_an_account_in_the_last_60_days do
+    read :female_public_users_who_created_an_account_in_the_last_number_of_days do
       prepare fn query, _context ->
-        date = DateTime.add(DateTime.utc_now(), -60, :day)
+        date =
+          DateTime.add(
+            DateTime.utc_now(),
+            -Application.get_env(:animina, :number_of_days_to_filter_registered_users),
+            :day
+          )
 
         Ash.Query.filter(
           query,
@@ -260,9 +265,14 @@ defmodule Animina.Accounts.User do
       pagination offset?: true, keyset?: true, required?: false
     end
 
-    read :male_public_users_who_created_an_account_in_the_last_60_days do
+    read :male_public_users_who_created_an_account_in_the_last_number_of_days do
       prepare fn query, _context ->
-        date = DateTime.add(DateTime.utc_now(), -60, :day)
+        date =
+          DateTime.add(
+            DateTime.utc_now(),
+            -Application.get_env(:animina, :number_of_days_to_filter_registered_users),
+            :day
+          )
 
         Ash.Query.filter(
           query,

--- a/lib/animina_web/components/top_navigation_components.ex
+++ b/lib/animina_web/components/top_navigation_components.ex
@@ -1155,7 +1155,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
   end
 
   defp three_random_public_female_users do
-    case FastUser.public_users_who_created_an_account_in_the_last_60_days(%{
+    case FastUser.public_users_who_created_an_account_in_the_last_number_of_days(%{
            limit: 3,
            gender: "female"
          }) do
@@ -1168,7 +1168,7 @@ defmodule AniminaWeb.TopNavigationCompontents do
   end
 
   defp three_random_public_male_users do
-    case FastUser.public_users_who_created_an_account_in_the_last_60_days(%{
+    case FastUser.public_users_who_created_an_account_in_the_last_number_of_days(%{
            limit: 3,
            gender: "male"
          }) do

--- a/test/animina/accounts/fast_user_test.exs
+++ b/test/animina/accounts/fast_user_test.exs
@@ -86,9 +86,12 @@ defmodule Animina.Accounts.FastUserTest do
          } do
       result =
         FastUser
-        |> Ash.ActionInput.for_action(:public_users_who_created_an_account_in_the_last_60_days, %{
-          gender: "male"
-        })
+        |> Ash.ActionInput.for_action(
+          :public_users_who_created_an_account_in_the_last_number_of_days,
+          %{
+            gender: "male"
+          }
+        )
         |> Ash.run_action()
 
       assert {:ok, users} = result
@@ -103,9 +106,12 @@ defmodule Animina.Accounts.FastUserTest do
          } do
       result =
         FastUser
-        |> Ash.ActionInput.for_action(:public_users_who_created_an_account_in_the_last_60_days, %{
-          gender: "female"
-        })
+        |> Ash.ActionInput.for_action(
+          :public_users_who_created_an_account_in_the_last_number_of_days,
+          %{
+            gender: "female"
+          }
+        )
         |> Ash.run_action()
 
       assert {:ok, users} = result


### PR DESCRIPTION
- I setup a dynamic number of days that we use to filter users registration time when we are showing potential partners on the sidebar .
For dev and test env , we have

```

# configures the number of days behind we check when showing users on the sidebar for potential partners
config :animina, :number_of_days_to_filter_registered_users, 60
```

And in prod , we have

```
# configures the number of days behind we check when showing users on the sidebar for potential partners

config :animina, :number_of_days_to_filter_registered_users, 600
```