### PR TITLE
Setup layout for flag selection

### DIFF
--- a/lib/animina_web/components/beta_registration_components.ex
+++ b/lib/animina_web/components/beta_registration_components.ex
@@ -118,7 +118,7 @@ defmodule AniminaWeb.BetaRegistrationComponents do
                 phx-value-flag={flag.name}
                 phx-value-flagid={flag.id}
                 aria-label="button"
-                class={"rounded-full flex gap-2 items-center  px-3 py-1.5 text-sm font-semibold leading-6  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2  #{get_default_button_colors(@color)} "
+                class={"rounded-full flex gap-2 items-center  px-3 py-1.5 text-sm font-semibold leading-6  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2  #{default_button_colors(@color)} "
 
             }
               >
@@ -142,18 +142,14 @@ defmodule AniminaWeb.BetaRegistrationComponents do
     """
   end
 
-  defp get_default_button_colors(color) do
-    cond do
-      color == :green ->
-        "hover:bg-green-50 bg-green-100 focus-visible:outline-green-100 text-green-600"
+  defp default_button_colors(:green),
+    do: "hover:bg-green-50 bg-green-100 focus-visible:outline-green-100 text-green-600"
 
-      color == :red ->
-        "hover:bg-red-50 bg-red-100 focus-visible:outline-red-100 text-red-600"
+  defp default_button_colors(:red),
+    do: "hover:bg-red-50 bg-red-100 focus-visible:outline-red-100 text-red-600"
 
-      true ->
-        "hover:bg-indigo-50 bg-indigo-100 focus-visible:outline-indigo-100 text-indigo-600"
-    end
-  end
+  defp default_button_colors(_),
+    do: "hover:bg-indigo-50 bg-indigo-100 focus-visible:outline-indigo-100 text-indigo-600"
 
   defp get_field_errors(field, _name) do
     Enum.map(field.errors, &translate_error(&1))

--- a/lib/animina_web/components/beta_registration_components.ex
+++ b/lib/animina_web/components/beta_registration_components.ex
@@ -84,6 +84,77 @@ defmodule AniminaWeb.BetaRegistrationComponents do
     """
   end
 
+  def flags_for_selection(assigns) do
+    ~H"""
+    <div class="relative px-5 space-y-4">
+      <div class="flex items-center justify-between">
+        <h2 class="font-bold dark:text-white md:text-xl"><%= @title %></h2>
+
+        <div>
+          <button
+            phx-click="add_flags"
+            class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 "
+          >
+            <%= with_locale(@language, fn -> %>
+              <%= gettext("Proceed ") %>
+            <% end) %>
+          </button>
+        </div>
+      </div>
+
+      <p class="dark:text-white"><%= @info_text %></p>
+
+      <div :for={category <- @categories}>
+        <div class="py-4 space-y-2">
+          <h3 class="font-semibold text-gray-800 dark:text-white truncate">
+            <%= with_locale(@language, fn -> %>
+              <%= Gettext.gettext(AniminaWeb.Gettext, Ash.CiString.value(category.name)) %>
+            <% end) %>
+          </h3>
+
+          <ol class="flex flex-wrap gap-2 w-full">
+            <li :for={flag <- category.flags}>
+              <div
+                phx-value-flag={flag.name}
+                phx-value-flagid={flag.id}
+                aria-label="button"
+                class={"rounded-full flex gap-2 items-center  px-3 py-1.5 text-sm font-semibold leading-6  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2  #{get_default_button_colors(@color)} "
+
+            }
+              >
+                <span :if={flag.emoji} class="pr-1.5"><%= flag.emoji %></span>
+
+                <%= with_locale(@language, fn -> %>
+                  <%= Gettext.gettext(AniminaWeb.Gettext, Ash.CiString.value(flag.name)) %>
+                <% end) %>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </div>
+
+      <button class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 ">
+        <%= with_locale(@language, fn -> %>
+          <%= gettext("Save flags") %>
+        <% end) %>
+      </button>
+    </div>
+    """
+  end
+
+  defp get_default_button_colors(color) do
+    cond do
+      color == :green ->
+        "hover:bg-green-50 bg-green-100 focus-visible:outline-green-100 text-green-600"
+
+      color == :red ->
+        "hover:bg-red-50 bg-red-100 focus-visible:outline-red-100 text-red-600"
+
+      true ->
+        "hover:bg-indigo-50 bg-indigo-100 focus-visible:outline-indigo-100 text-indigo-600"
+    end
+  end
+
   defp get_field_errors(field, _name) do
     Enum.map(field.errors, &translate_error(&1))
   end

--- a/lib/animina_web/live/beta_register.ex
+++ b/lib/animina_web/live/beta_register.ex
@@ -33,80 +33,66 @@ defmodule AniminaWeb.BetaRegisterLive do
 
   @impl true
 
-  def handle_params(%{"step" => "select_white_flags"}, _url, socket) do
-    {:noreply,
-     socket
-     |> assign(:color, :white)
-     |> assign(categories: fetch_categories())
-     |> assign(
-       title: with_locale(socket.assigns.language, fn -> gettext("Choose Your Own Flags") end)
-     )
-     |> assign(
-       info_text:
-         with_locale(socket.assigns.language, fn ->
-           gettext(
-             "We use flags to match people. You can select red and green flags later. But first tell us something about yourself and select up to %{number_of_flags} flags that describe yourself. The ones selected first are the most important.",
-             number_of_flags: @max_flags
-           )
-         end)
-     )
-     |> assign(
-       page_title:
-         with_locale(socket.assigns.language, fn -> gettext("Select your own flags") end)
-     )
-     |> assign(:step, "select_flags")}
-  end
+  def handle_params(%{"step" => step}, _url, socket) do
+    {color, page_title_str, title_str, info_text_str} =
+      step_info(step, socket.assigns.language, @max_flags)
 
-  def handle_params(%{"step" => "select_green_flags"}, _url, socket) do
-    {:noreply,
-     socket
-     |> assign(
-       page_title:
-         with_locale(socket.assigns.language, fn -> gettext("Select your green flags") end)
-     )
-     |> assign(:color, :green)
-     |> assign(categories: fetch_categories())
-     |> assign(
-       title: with_locale(socket.assigns.language, fn -> gettext("Choose Your Green Flags") end)
-     )
-     |> assign(
-       info_text:
-         with_locale(socket.assigns.language, fn ->
-           gettext(
-             "Choose up to %{number_of_flags} flags that you want your partner to have. The ones selected first are the most important.",
-             number_of_flags: @max_flags
-           )
-         end)
-     )
-     |> assign(:step, "select_flags")}
-  end
-
-  def handle_params(%{"step" => "select_red_flags"}, _url, socket) do
-    {:noreply,
-     socket
-     |> assign(:color, :red)
-     |> assign(
-       page_title:
-         with_locale(socket.assigns.language, fn -> gettext("Select your red flags") end)
-     )
-     |> assign(categories: fetch_categories())
-     |> assign(
-       title: with_locale(socket.assigns.language, fn -> gettext("Choose Your Red Flags") end)
-     )
-     |> assign(
-       info_text:
-         with_locale(socket.assigns.language, fn ->
-           gettext(
-             "Choose up to %{number_of_flags} flags that you don't want to have in a partner. The ones selected first are the most important.",
-             number_of_flags: @max_flags
-           )
-         end)
-     )
-     |> assign(:step, "select_flags")}
+    {:noreply, assign_flags(socket, color, page_title_str, title_str, info_text_str)}
   end
 
   def handle_params(_, _url, socket) do
     {:noreply, socket |> assign(:step, "filter_potential_partners")}
+  end
+
+  defp step_info("select_white_flags", language, _) do
+    {
+      :white,
+      with_locale(language, fn -> gettext("Select your own flags") end),
+      with_locale(language, fn -> gettext("Choose Your Own Flags") end),
+      with_locale(language, fn ->
+        gettext(
+          "We use flags to match people. You can select red and green flags later. But first tell us something about yourself and select up to %{number_of_flags} flags that describe yourself. The ones selected first are the most important."
+        )
+      end)
+    }
+  end
+
+  defp step_info("select_green_flags", language, number_of_flags) do
+    {
+      :green,
+      with_locale(language, fn -> gettext("Select your green flags") end),
+      with_locale(language, fn -> gettext("Choose Your Green Flags") end),
+      with_locale(language, fn ->
+        gettext(
+          "Choose up to %{number_of_flags} flags that you want your partner to have. The ones selected first are the most important.",
+          number_of_flags: number_of_flags
+        )
+      end)
+    }
+  end
+
+  defp step_info("select_red_flags", language, number_of_flags) do
+    {
+      :red,
+      with_locale(language, fn -> gettext("Select your red flags") end),
+      with_locale(language, fn -> gettext("Choose Your Red Flags") end),
+      with_locale(language, fn ->
+        gettext(
+          "Choose up to %{number_of_flags} flags that you don't want to have in a partner. The ones selected first are the most important.",
+          number_of_flags: number_of_flags
+        )
+      end)
+    }
+  end
+
+  defp assign_flags(socket, color, page_title_str, title_str, info_text_str) do
+    socket
+    |> assign(:color, color)
+    |> assign(:categories, fetch_categories())
+    |> assign(:title, title_str)
+    |> assign(:info_text, info_text_str)
+    |> assign(:page_title, page_title_str)
+    |> assign(:step, "select_flags")
   end
 
   @impl true

--- a/lib/animina_web/live/beta_register.ex
+++ b/lib/animina_web/live/beta_register.ex
@@ -2,9 +2,11 @@ defmodule AniminaWeb.BetaRegisterLive do
   use AniminaWeb, :live_view
   alias Animina.Accounts.User
   alias Animina.BirthdayValidator
+  alias Animina.Traits
   alias AniminaWeb.PotentialPartner
   alias AshPhoenix.Form
 
+  @max_flags Application.compile_env(:animina, AniminaWeb.FlagsLive)[:max_selected]
   @impl true
   def mount(_params, %{"language" => language} = _session, socket) do
     potential_partners =
@@ -18,6 +20,7 @@ defmodule AniminaWeb.BetaRegisterLive do
       |> assign(active_tab: "register")
       |> assign(trigger_action: false)
       |> assign(current_user_credit_points: 0)
+      |> assign(:step, "filter_potential_partners")
       |> assign(:number_of_potential_partners, Enum.count(potential_partners))
       |> assign(:errors, [])
       |> assign(
@@ -26,6 +29,82 @@ defmodule AniminaWeb.BetaRegisterLive do
       )
 
     {:ok, socket}
+  end
+
+  def handle_params(%{"step" => "select_white_flags"}, _url, socket) do
+    {:noreply,
+     socket
+     |> assign(:color, :white)
+     |> assign(categories: fetch_categories())
+     |> assign(
+       title: with_locale(socket.assigns.language, fn -> gettext("Choose Your Own Flags") end)
+     )
+     |> assign(
+       info_text:
+         with_locale(socket.assigns.language, fn ->
+           gettext(
+             "We use flags to match people. You can select red and green flags later. But first tell us something about yourself and select up to %{number_of_flags} flags that describe yourself. The ones selected first are the most important.",
+             number_of_flags: @max_flags
+           )
+         end)
+     )
+     |> assign(
+       page_title:
+         with_locale(socket.assigns.language, fn -> gettext("Select your own flags") end)
+     )
+     |> assign(:step, "select_flags")}
+  end
+
+  def handle_params(%{"step" => "select_green_flags"}, _url, socket) do
+    {:noreply,
+     socket
+     |> assign(
+       page_title:
+         with_locale(socket.assigns.language, fn -> gettext("Select your green flags") end)
+     )
+     |> assign(:color, :green)
+     |> assign(categories: fetch_categories())
+     |> assign(
+       title: with_locale(socket.assigns.language, fn -> gettext("Choose Your Green Flags") end)
+     )
+     |> assign(
+       info_text:
+         with_locale(socket.assigns.language, fn ->
+           gettext(
+             "Choose up to %{number_of_flags} flags that you want your partner to have. The ones selected first are the most important.",
+             number_of_flags: @max_flags
+           )
+         end)
+     )
+     |> assign(:step, "select_flags")}
+  end
+
+  def handle_params(%{"step" => "select_red_flags"}, _url, socket) do
+    {:noreply,
+     socket
+     |> assign(:color, :red)
+     |> assign(
+       page_title:
+         with_locale(socket.assigns.language, fn -> gettext("Select your red flags") end)
+     )
+     |> assign(categories: fetch_categories())
+     |> assign(
+       title: with_locale(socket.assigns.language, fn -> gettext("Choose Your Red Flags") end)
+     )
+     |> assign(
+       info_text:
+         with_locale(socket.assigns.language, fn ->
+           gettext(
+             "Choose up to %{number_of_flags} flags that you don't want to have in a partner. The ones selected first are the most important.",
+             number_of_flags: @max_flags
+           )
+         end)
+     )
+     |> assign(:step, "select_flags")}
+  end
+
+  def handle_params(_, _url, socket) do
+    {:noreply, socket |> assign(:step, "filter_potential_partners")}
   end
 
   @impl true
@@ -61,16 +140,32 @@ defmodule AniminaWeb.BetaRegisterLive do
     }
   end
 
+  defp fetch_categories do
+    Traits.Category
+    |> Ash.Query.for_read(:read)
+    |> Ash.read!()
+  end
+
   @impl true
   def render(assigns) do
     ~H"""
     <div>
       <.initial_form
+        :if={@step == "filter_potential_partners"}
         number_of_potential_partners={@number_of_potential_partners}
         language={@language}
         birthday_error={@birthday_error}
         form={@form}
         errors={@errors}
+      />
+
+      <.flags_for_selection
+        :if={@step == "select_flags"}
+        color={@color}
+        categories={@categories}
+        title={@title}
+        info_text={@info_text}
+        language={@language}
       />
     </div>
     """

--- a/lib/animina_web/live/beta_register.ex
+++ b/lib/animina_web/live/beta_register.ex
@@ -31,6 +31,8 @@ defmodule AniminaWeb.BetaRegisterLive do
     {:ok, socket}
   end
 
+  @impl true
+
   def handle_params(%{"step" => "select_white_flags"}, _url, socket) do
     {:noreply,
      socket


### PR DESCRIPTION
I setup the layout for flags selection in the new registration flow at

```
"/beta?step=select_white_flags"
"/beta?step=select_red_flags"
"/beta?step=select_green_flags"

```
<img width="1440" alt="Screenshot 2024-12-17 at 11 56 46" src="https://github.com/user-attachments/assets/1eea9e34-6824-4568-910c-4ea85dc1fb30" />

<img width="1440" alt="Screenshot 2024-12-17 at 11 56 37" src="https://github.com/user-attachments/assets/77b7abc1-f9b9-4f2a-aa74-f03eda8d4113" />

<img width="1440" alt="Screenshot 2024-12-17 at 11 56 29" src="https://github.com/user-attachments/assets/46497ee6-b4a3-40be-bb89-245830c34db4" />
