### PR TITLE
I ensured we do not see opposite selected flags

### DIFF
--- a/lib/animina_web/components/beta_registration_components.ex
+++ b/lib/animina_web/components/beta_registration_components.ex
@@ -87,12 +87,15 @@ defmodule AniminaWeb.BetaRegistrationComponents do
   def flags_for_selection(assigns) do
     ~H"""
     <div class="relative px-5 space-y-4">
+      <.previous_step color={@color} language={@language} />
+
       <div class="flex items-center justify-between">
         <h2 class="font-bold dark:text-white md:text-xl"><%= @title %></h2>
 
         <div>
           <button
-            phx-click="add_flags"
+            phx-click="move_to_next_step"
+            phx-value-color={@color}
             class="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 "
           >
             <%= with_locale(@language, fn -> %>
@@ -113,7 +116,20 @@ defmodule AniminaWeb.BetaRegistrationComponents do
           </h3>
 
           <ol class="flex flex-wrap gap-2 w-full">
-            <li :for={flag <- category.flags}>
+            <li
+              :for={flag <- category.flags}
+              :if={
+                Enum.member?(
+                  opposite_color_flags_selected(
+                    @color,
+                    @user_green_flags,
+                    @user_red_flags,
+                    @user_white_flags
+                  ),
+                  flag.id
+                ) == false
+              }
+            >
               <div
                 phx-value-flag={flag.name}
                 phx-value-flagid={flag.id}
@@ -203,6 +219,18 @@ defmodule AniminaWeb.BetaRegistrationComponents do
   defp get_position_colors(:green), do: "text-green-600 bg-green-200"
   defp get_position_colors(:red), do: "text-rose-600 bg-rose-200"
   defp get_position_colors(_), do: "text-indigo-600 bg-indigo-200"
+
+  defp opposite_color_flags_selected(:green, u_ser_green_flags, user_red_flags, _user_white_flags) do
+    user_red_flags
+  end
+
+  defp opposite_color_flags_selected(:red, user_green_flags, _user_red_flags, _user_white_flags) do
+    user_green_flags
+  end
+
+  defp opposite_color_flags_selected(:white, _, _, _) do
+    []
+  end
 
   defp get_field_errors(field, _name) do
     Enum.map(field.errors, &translate_error(&1))
@@ -581,6 +609,22 @@ defmodule AniminaWeb.BetaRegistrationComponents do
           <% end) %>
         </.error>
       </div>
+    </div>
+    """
+  end
+
+  defp previous_step(assigns) do
+    ~H"""
+    <div class="flex items-start">
+      <button
+        phx-click="move_to_previous_step"
+        phx-value-color={@color}
+        class="flex  justify-center    text-sm font-semibold text-white shadow-sm  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 "
+      >
+        <%= with_locale(@language, fn -> %>
+          <%= gettext("Back") %>
+        <% end) %>
+      </button>
     </div>
     """
   end

--- a/lib/animina_web/components/beta_registration_components.ex
+++ b/lib/animina_web/components/beta_registration_components.ex
@@ -220,7 +220,7 @@ defmodule AniminaWeb.BetaRegistrationComponents do
   defp get_position_colors(:red), do: "text-rose-600 bg-rose-200"
   defp get_position_colors(_), do: "text-indigo-600 bg-indigo-200"
 
-  defp opposite_color_flags_selected(:green, u_ser_green_flags, user_red_flags, _user_white_flags) do
+  defp opposite_color_flags_selected(:green, _user_green_flags, user_red_flags, _user_white_flags) do
     user_red_flags
   end
 

--- a/lib/animina_web/live/beta_register.ex
+++ b/lib/animina_web/live/beta_register.ex
@@ -127,6 +127,44 @@ defmodule AniminaWeb.BetaRegisterLive do
     {:noreply, socket}
   end
 
+  def handle_event("move_to_next_step", %{"color" => color}, socket) do
+    case color do
+      "white" ->
+        {:noreply,
+         socket
+         |> push_patch(to: "/beta?step=select_green_flags")}
+
+      "green" ->
+        {:noreply,
+         socket
+         |> push_patch(to: "/beta?step=select_red_flags")}
+
+      "red" ->
+        {:noreply,
+         socket
+         |> push_patch(to: "/beta?step=select_red_flags")}
+    end
+  end
+
+  def handle_event("move_to_previous_step", %{"color" => color}, socket) do
+    case color do
+      "white" ->
+        {:noreply,
+         socket
+         |> push_patch(to: "/beta")}
+
+      "green" ->
+        {:noreply,
+         socket
+         |> push_patch(to: "/beta?step=select_white_flags")}
+
+      "red" ->
+        {:noreply,
+         socket
+         |> push_patch(to: "/beta?step=select_green_flags")}
+    end
+  end
+
   defp update_flags_array(:add, color, flagid, socket) do
     assign_key = get_assign_key(color)
 


### PR DESCRIPTION
In this PR , I ensured we do not show opposite selected color flags , which means if we select "Courage" as a green flag , when you go to select red flags , you do not see this flag.
I also setup the proceed and back buttons


https://github.com/user-attachments/assets/26d369b0-bcd0-46a6-b4c0-7afa1da9287c

